### PR TITLE
Latest build of go-simplejson has broken lookupd interaction

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -527,16 +527,29 @@ func (q *Reader) queryLookupd() {
 		return
 	}
 
-	// {"data":{"channels":[],"producers":[{"address":"jehiah-air.local", "tpc_port":4150, "http_port":4151}],"timestamp":1340152173},"status_code":200,"status_txt":"OK"}
-	producers, _ := data.Get("producers").Array()
-	for _, producer := range producers {
-		producerData, _ := producer.(map[string]interface{})
-		address := producerData["address"].(string)
-		broadcastAddress, ok := producerData["broadcast_address"]
+	// {
+	//     "data": {
+	//         "channels": [],
+	//         "producers": [
+	//             {
+	//                 "broadcast_address": "jehiah-air.local",
+	//                 "http_port": 4151,
+	//                 "tcp_port": 4150
+	//             }
+	//         ],
+	//         "timestamp": 1340152173
+	//     },
+	//     "status_code": 200,
+	//     "status_txt": "OK"
+	// }
+	for i, _ := range data.Get("producers").MustArray() {
+		producer := data.Get("producers").GetIndex(i)
+		address := producer.Get("address").MustString()
+		broadcastAddress, ok := producer.CheckGet("broadcast_address")
 		if ok {
-			address = broadcastAddress.(string)
+			address = broadcastAddress.MustString()
 		}
-		port := int(producerData["tcp_port"].(float64))
+		port := producer.Get("tcp_port").MustInt()
 
 		// make an address, start a connection
 		joined := net.JoinHostPort(address, strconv.Itoa(port))


### PR DESCRIPTION
I think the changes made here https://github.com/bitly/go-simplejson/commit/7f4699f47869d2c308a78239e255f63eec927ec0 have broken my nsq client. It now panics when trying to parse nsqlookupd response. See below panic stack and json response it's trying to parse when panicking. (Admittedly it's an old version of nsqlookupd)

```
{
  "data": {
    "producers": [
      {
        "version": "0.2.18",
        "http_port": 4151,
        "tcp_port": 4150,
        "broadcast_address": "vpcutilities03-global01-test",
        "hostname": "vpcutilities03-global01-test",
        "address": "vpcutilities03-global01-test"
      },
      {
        "version": "0.2.18",
        "http_port": 4151,
        "tcp_port": 4150,
        "broadcast_address": "vpcutilities02-global01-test",
        "hostname": "vpcutilities02-global01-test",
        "address": "vpcutilities02-global01-test"
      },
      {
        "version": "0.2.18",
        "http_port": 4151,
        "tcp_port": 4150,
        "broadcast_address": "vpcutilities01-global01-test",
        "hostname": "vpcutilities01-global01-test",
        "address": "vpcutilities01-global01-test"
      }
    ],
    "channels": [
      "revpro.listener.johnworrell",
      "revpro.listener.hailo",
      "gamification",
      "acunuworker",
      "exp-event-augmenter-dom",
      "exp-event-augmenter"
    ]
  },
  "status_txt": "OK",
  "status_code": 200
}


panic: interface conversion: interface is json.Number, not float64

goroutine 1 [running]:
github.com/hailocab/go-nsq.(*Reader).queryLookupd(0xc2002fa000)
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-nsq/reader.go:447 +0x59d
github.com/hailocab/go-nsq.(*Reader).ConnectToLookupd(0xc2002fa000, 0xc20025e540, 0x30, 0x1, 0x1, ...)
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-nsq/reader.go:378 +0x25d
github.com/hailocab/go-service-layer/nsq.(*LookupdSubscriber).configure(0xc200258840)
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-service-layer/nsq/subscriber.go:57 +0x693
github.com/hailocab/go-service-layer/nsq.*LookupdSubscriber.(github.com/hailocab/go-service-layer/nsq.configure)·fm()
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-service-layer/nsq/subscriber.go:25 +0x24
sync.(*Once).Do(0xc200258858, 0xbc97a8)
    /opt/boxen/homebrew/Cellar/go/1.1/src/pkg/sync/once.go:40 +0x7e
github.com/hailocab/go-service-layer/nsq.(*LookupdSubscriber).AddAsyncHandler(0xc200258840, 0xc200258870, 0xc2002cf1c0)
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-service-layer/nsq/subscriber.go:36 +0x78
github.com/hailocab/go-service-layer/acunu/ingester.New(0x61acd0, 0x12, 0x5ec9b0, 0xc, 0x0, ...)
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-service-layer/acunu/ingester/ingester.go:73 +0x57d
github.com/hailocab/go-service-layer/acunu/ingester.func·001()
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-service-layer/acunu/ingester/ingester.go:90 +0x57
github.com/hailocab/go-platform-layer/server.doRun(0x0)
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-platform-layer/server/server.go:236 +0x3b0
github.com/hailocab/go-platform-layer/server.Run()
    /Users/dominic/development/goworkspace/src/github.com/hailocab/go-platform-layer/server/server.go:206 +0x20
main.main()
    /Users/dominic/development/goworkspace/src/github.com/hailocab/gamification-service/main.go:27 +0x224 
```
