### PR TITLE
Per-message Requeue

### DIFF
--- a/message.go
+++ b/message.go
@@ -40,6 +40,12 @@ func (m *Message) Touch() {
 	m.cmdChan <- Touch(m.Id)
 }
 
+// Requeue sends a REQUEUE command to the nsqd which
+// sent this message, using the supplied delay
+func (m *Message) Requeue(timeoutMs int) {
+	m.cmdChan <- Requeue(m.Id, timeoutMs)
+}
+
 // EncodeBytes serializes the message into a new, returned, []byte
 func (m *Message) EncodeBytes() ([]byte, error) {
 	var buf bytes.Buffer


### PR DESCRIPTION
Adding `Requeue()` method to messages for fine-grained control on requeue delays on message-by-message basis.

Copied the same approach used as for `Touch()`.

Copied the same interface for `Requeue` -- with `timeoutMs int` rather than a Go Duration - as it seemed a better fit with the existing codebase.
