### PR TITLE
handleError() loops if already connected

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -541,7 +541,7 @@ func handleError(q *Reader, c *nsqConn, errMsg string) {
 					break
 				}
 				err := q.ConnectToNSQ(addr)
-				if err != nil {
+				if err != nil && err != ErrAlreadyConnected {
 					log.Printf("ERROR: failed to connect to %s - %s",
 						addr, err.Error())
 					continue


### PR DESCRIPTION
handleError doesn't check for "already connected" error causing loop
