### PR TITLE
Allow for more types of channel names

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -24,7 +24,7 @@ const (
 const DefaultClientTimeout = 60 * time.Second
 
 var validTopicNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+$`)
-var validChannelNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+(#ephemeral)?$`)
+var validChannelNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+(#[\.;a-zA-Z0-9_\-=]+)?$`)
 
 // IsValidTopicName checks a topic name for correctness
 func IsValidTopicName(name string) bool {


### PR DESCRIPTION
In order to complete bitly/nsq#223, the allowable regex for a channel needs to be changed.
