### PR TITLE
show topic/channel for connection logs

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -27,6 +27,9 @@ type nsqConn struct {
 
 	sync.Mutex
 
+	topic   string
+	channel string
+
 	net.Conn
 	tlsConn *tls.Conn
 	addr    string
@@ -54,6 +57,7 @@ type nsqConn struct {
 }
 
 func newNSQConn(rdyChan chan *nsqConn, addr string,
+	topic string, channel string,
 	readTimeout time.Duration, writeTimeout time.Duration) (*nsqConn, error) {
 	conn, err := net.DialTimeout("tcp", addr, time.Second)
 	if err != nil {
@@ -64,6 +68,9 @@ func newNSQConn(rdyChan chan *nsqConn, addr string,
 		Conn: conn,
 
 		addr: addr,
+
+		topic:   topic,
+		channel: channel,
 
 		r: conn,
 		w: conn,
@@ -90,7 +97,7 @@ func newNSQConn(rdyChan chan *nsqConn, addr string,
 }
 
 func (c *nsqConn) String() string {
-	return c.addr
+	return fmt.Sprintf("%s/%s/%s", c.addr, c.topic, c.channel)
 }
 
 func (c *nsqConn) Read(p []byte) (int, error) {

--- a/reader.go
+++ b/reader.go
@@ -617,7 +617,8 @@ func (q *Reader) ConnectToNSQ(addr string) error {
 
 	log.Printf("[%s] connecting to nsqd", addr)
 
-	connection, err := newNSQConn(q.rdyChan, addr, q.ReadTimeout, q.WriteTimeout)
+	connection, err := newNSQConn(q.rdyChan, addr,
+		q.TopicName, q.ChannelName, q.ReadTimeout, q.WriteTimeout)
 	if err != nil {
 		return err
 	}
@@ -725,7 +726,7 @@ func (q *Reader) ConnectToNSQ(addr string) error {
 
 	q.Lock()
 	delete(q.pendingConnections, addr)
-	q.nsqConnections[connection.String()] = connection
+	q.nsqConnections[addr] = connection
 	q.Unlock()
 
 	// pre-emptive signal to existing connections to lower their RDY count
@@ -969,7 +970,7 @@ func (q *Reader) cleanupConnection(c *nsqConn) {
 	c.Unlock()
 
 	q.Lock()
-	delete(q.nsqConnections, c.String())
+	delete(q.nsqConnections, c.addr)
 	left := len(q.nsqConnections)
 	q.Unlock()
 


### PR DESCRIPTION
when you have multiple readers in a process it is otherwise
impossible to disambiguate.

had this laying around actually :)

cc @domwong @davegardnerisme
