### PR TITLE
unintuitive behavior when using &nsq.Config{} 

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -90,6 +90,7 @@ type Conn struct {
 
 // NewConn returns a new Conn instance
 func NewConn(addr string, config *Config) *Conn {
+	config.initialize()
 	return &Conn{
 		addr: addr,
 

--- a/consumer.go
+++ b/consumer.go
@@ -112,6 +112,8 @@ type Consumer struct {
 // The returned Consumer instance is setup with sane default values.  To modify
 // configuration, update the values on the returned instance before connecting.
 func NewConsumer(topic string, channel string, config *Config) (*Consumer, error) {
+	config.initialize()
+
 	if !IsValidTopicName(topic) {
 		return nil, errors.New("invalid topic name")
 	}

--- a/producer.go
+++ b/producer.go
@@ -56,6 +56,7 @@ func (t *ProducerTransaction) finish() {
 
 // NewProducer returns an instance of Producer for the specified address
 func NewProducer(addr string, config *Config) *Producer {
+	config.initialize()
 	return &Producer{
 		id: atomic.AddInt64(&instCount, 1),
 


### PR DESCRIPTION
I got this on Ubuntu 12.04, go 1.2

```
panic: non-positive interval for NewTicker

goroutine 141 [running]:
runtime.panic(0x815520, 0xc21010d230)
    /usr/local/go/src/pkg/runtime/panic.c:266 +0xb6
time.NewTicker(0x0, 0x3fd8a050fdd8d7f5)
    /usr/local/go/src/pkg/time/tick.go:22 +0x9f
github.com/bitly/go-nsq.(*Consumer).lookupdLoop(0xc21005a8c0)
    /tmp/godep/rev/2b/9a8b5edc036235580256e9a5e5f118a0025151/src/github.com/bitly/go-nsq/consumer.go:228 +0x6e
created by github.com/bitly/go-nsq.(*Consumer).ConnectToNSQLookupd
    /tmp/godep/rev/2b/9a8b5edc036235580256e9a5e5f118a0025151/src/github.com/bitly/go-nsq/consumer.go:216 +0x282
```

This is https://github.com/bitly/go-nsq/commit/2b9a8b5edc036235580256e9a5e5f118a0025151

I'm connecting to 8 nsqlookupd hosts (which might increase the chance of this happening)

I'm not setting config.lookupdPollInterval in my code.
