### PR TITLE
auth support for lookupd connections.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -19,10 +19,6 @@ var ErrAlreadyConnected = errors.New("already connected")
 // ErrOverMaxInFlight is returned from Consumer if over max-in-flight
 var ErrOverMaxInFlight = errors.New("over configure max-inflight")
 
-// ErrLookupdAddressExists is returned from ConnectToNSQLookupd
-// when given lookupd address exists already
-var ErrLookupdAddressExists = errors.New("lookupd address already exists")
-
 // ErrIdentify is returned from Conn as part of the IDENTIFY handshake
 type ErrIdentify struct {
 	Reason string


### PR DESCRIPTION
This adds the capability to query lookupd over ssl, and sends along the configured authSecret when configured. This will allow for untrusted users to only get information back from a lookup endpoint w/ information for hosts they are permissioned to connect to.

cc: @mreiferson
