### PR TITLE
restore SetMaxInFlight dropped in refactoring

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,8 +53,7 @@ type Config struct {
 	outputBufferSize    int64         `opt:"output_buffer_size"`
 	outputBufferTimeout time.Duration `opt:"output_buffer_timeout"`
 
-	maxInFlight      int `opt:"max_in_flight" min:"0"`
-	maxInFlightMutex sync.RWMutex
+	maxInFlight int `opt:"max_in_flight" min:"0"`
 
 	maxBackoffDuration time.Duration `opt:"max_backoff_duration" min:"0" max:"60m"`
 

--- a/consumer.go
+++ b/consumer.go
@@ -194,6 +194,24 @@ func (r *Consumer) maxInFlight() int {
 	return mif
 }
 
+// SetMaxInFlight sets the maximum number of messages this comsumer instance
+// will allow in-flight.
+//
+// If already connected, it updates the reader RDY state for each connection.
+func (r *Consumer) SetMaxInFlight(maxInFlight int) {
+	r.config.RLock()
+	mif := r.config.maxInFlight
+	r.config.RUnlock()
+	if mif == maxInFlight {
+		return
+	}
+	r.config.Set("max_in_flight", maxInFlight)
+
+	for _, c := range r.conns() {
+		r.rdyChan <- c
+	}
+}
+
 // ConnectToNSQLookupd adds an nsqlookupd address to the list for this Consumer instance.
 //
 // If it is the first to be added, it initiates an HTTP request to discover nsqd


### PR DESCRIPTION
Consumer needs to export a way to update the max-in-flight as a way to pause or resume a client from doing work. This was accidentally dropped in #30 
