### PR TITLE
separate handlers for concurrent handlers

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -118,7 +118,7 @@ func consumerTest(t *testing.T, deflate bool, snappy bool, tlsv1 bool) {
 		t: t,
 		q: q,
 	}
-	q.SetHandler(h)
+	q.AddHandler(h)
 
 	SendMessage(t, 4151, topicName, "put", []byte(`{"msg":"single"}`))
 	SendMessage(t, 4151, topicName, "mput", []byte("{\"msg\":\"double\"}\n{\"msg\":\"double\"}"))

--- a/mock_test.go
+++ b/mock_test.go
@@ -222,7 +222,7 @@ func TestConsumerBackoff(t *testing.T) {
 	config.BackoffMultiplier = 10 * time.Millisecond
 	q, _ := NewConsumer(topicName, "ch", config)
 	q.SetLogger(logger, LogLevelDebug)
-	q.SetHandler(&testHandler{})
+	q.AddHandler(&testHandler{})
 	err := q.ConnectToNSQD(n.tcpAddr.String())
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/producer_test.go
+++ b/producer_test.go
@@ -253,7 +253,7 @@ func readMessages(topicName string, t *testing.T, msgCount int) {
 		t: t,
 		q: q,
 	}
-	q.SetHandler(h)
+	q.AddHandler(h)
 
 	err := q.ConnectToNSQD("127.0.0.1:4150")
 	if err != nil {


### PR DESCRIPTION
An unexpected api regression/change is that you can't set concurrent handlers to each use their own handler object. This was useful when you wanted separate state for each concurrent handler.

The current api doesn't allow you to call `SetHandler` or `SetConcurrentHandlers` multiple times, but i don't see a strict reason not to allow that. Thoughts @mreiferson 
