### PR TITLE
config: export & list defaults

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -14,3 +14,15 @@ func TestConfigSet(t *testing.T) {
 		t.Errorf("Error setting `tls_v1` config: %v", err)
 	}
 }
+
+func TestConfigValidate(t *testing.T) {
+	c := NewConfig()
+	if err := c.Validate(); err != nil {
+		t.Error("initialized config is invalid")
+	}
+	c.DeflateLevel = 100
+	if err := c.Validate(); err == nil {
+		t.Error("no error set for invalid value")
+	}
+
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -218,8 +218,8 @@ func TestConsumerBackoff(t *testing.T) {
 
 	topicName := "test_consumer_commands" + strconv.Itoa(int(time.Now().Unix()))
 	config := NewConfig()
-	config.Set("max_in_flight", 5)
-	config.Set("backoff_multiplier", 10*time.Millisecond)
+	config.MaxInFlight = 5
+	config.BackoffMultiplier = 10 * time.Millisecond
 	q, _ := NewConsumer(topicName, "ch", config)
 	q.SetLogger(logger, LogLevelDebug)
 	q.SetHandler(&testHandler{})

--- a/producer_test.go
+++ b/producer_test.go
@@ -39,7 +39,8 @@ func TestProducerConnection(t *testing.T) {
 	defer log.SetOutput(os.Stdout)
 
 	config := NewConfig()
-	w := NewProducer("127.0.0.1:4150", config)
+	w, _ := NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
 
 	err := w.Publish("write_test", []byte("test"))
 	if err != nil {
@@ -62,7 +63,8 @@ func TestProducerPublish(t *testing.T) {
 	msgCount := 10
 
 	config := NewConfig()
-	w := NewProducer("127.0.0.1:4150", config)
+	w, _ := NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
 	defer w.Stop()
 
 	for i := 0; i < msgCount; i++ {
@@ -88,7 +90,8 @@ func TestProducerMultiPublish(t *testing.T) {
 	msgCount := 10
 
 	config := NewConfig()
-	w := NewProducer("127.0.0.1:4150", config)
+	w, _ := NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
 	defer w.Stop()
 
 	var testData [][]byte
@@ -117,7 +120,8 @@ func TestProducerPublishAsync(t *testing.T) {
 	msgCount := 10
 
 	config := NewConfig()
-	w := NewProducer("127.0.0.1:4150", config)
+	w, _ := NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
 	defer w.Stop()
 
 	responseChan := make(chan *ProducerTransaction, msgCount)
@@ -154,7 +158,8 @@ func TestProducerMultiPublishAsync(t *testing.T) {
 	msgCount := 10
 
 	config := NewConfig()
-	w := NewProducer("127.0.0.1:4150", config)
+	w, _ := NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
 	defer w.Stop()
 
 	var testData [][]byte
@@ -194,8 +199,9 @@ func TestProducerHeartbeat(t *testing.T) {
 	topicName := "heartbeat" + strconv.Itoa(int(time.Now().Unix()))
 
 	config := NewConfig()
-	config.Set("heartbeat_interval", 100*time.Millisecond)
-	w := NewProducer("127.0.0.1:4150", config)
+	config.HeartbeatInterval = 100 * time.Millisecond
+	w, _ := NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
 	defer w.Stop()
 
 	err := w.Publish(topicName, []byte("publish_test_case"))
@@ -208,8 +214,9 @@ func TestProducerHeartbeat(t *testing.T) {
 	}
 
 	config = NewConfig()
-	config.Set("heartbeat_interval", 1000*time.Millisecond)
-	w = NewProducer("127.0.0.1:4150", config)
+	config.HeartbeatInterval = 1000 * time.Millisecond
+	w, _ = NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
 	defer w.Stop()
 
 	err = w.Publish(topicName, []byte("publish_test_case"))
@@ -237,9 +244,10 @@ func TestProducerHeartbeat(t *testing.T) {
 
 func readMessages(topicName string, t *testing.T, msgCount int) {
 	config := NewConfig()
-	config.Set("default_requeue_delay", 0)
-	config.Set("max_backoff_duration", time.Millisecond*50)
+	config.DefaultRequeueDelay = 0
+	config.MaxBackoffDuration = 50 * time.Millisecond
 	q, _ := NewConsumer(topicName, "ch", config)
+	q.SetLogger(nullLogger, LogLevelInfo)
 
 	h := &ConsumerHandler{
 		t: t,

--- a/protocol.go
+++ b/protocol.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"regexp"
-	"time"
 )
 
 // MagicV1 is the initial identifier sent when connecting for V1 clients
@@ -20,9 +19,6 @@ const (
 	FrameTypeError    int32 = 1
 	FrameTypeMessage  int32 = 2
 )
-
-// The amount of time nsqd will allow a client to idle, can be overriden
-const DefaultClientTimeout = 60 * time.Second
 
 var validTopicNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+$`)
 var validChannelNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+(#ephemeral)?$`)


### PR DESCRIPTION
@mreiferson this is a continuation of conversation in #47

This makes all config values exported, but copies them into a separate config object in Consumer and Producer so they can only be modified before you pass to a Consumer and Producer. This should mitigate the previous need to unexport fields.

I've also added a new way to denote defaults by marking them with struct tags. I like how this comes out by avoiding comments that might stray from the code values actually defaulting. I took a slightly different approach to just panic if an uninitialized config object is ever encountered.

thoughts?
