### PR TITLE
non-obvious nsq.Conn requiring nsq.ConnDelegate

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -427,10 +427,9 @@ func (r *Consumer) ConnectToNSQD(addr string) error {
 
 	r.log(LogLevelInfo, "(%s) connecting to nsqd", addr)
 
-	conn := NewConn(addr, &r.config)
+	conn := NewConn(addr, &r.config, &consumerConnDelegate{r})
 	conn.SetLogger(r.logger, r.logLvl,
 		fmt.Sprintf("%3d [%s/%s] (%%s)", r.id, r.topic, r.channel))
-	conn.Delegate = &consumerConnDelegate{r}
 
 	cleanupConnection := func() {
 		r.mtx.Lock()

--- a/producer.go
+++ b/producer.go
@@ -212,9 +212,8 @@ func (w *Producer) connect() error {
 
 	w.log(LogLevelInfo, "(%s) connecting to nsqd", w.addr)
 
-	conn := NewConn(w.addr, &w.config)
+	conn := NewConn(w.addr, &w.config, &producerConnDelegate{w})
 	conn.SetLogger(w.logger, w.logLvl, fmt.Sprintf("%3d (%%s)", w.id))
-	conn.Delegate = &producerConnDelegate{w}
 
 	_, err := conn.Connect()
 	if err != nil {


### PR DESCRIPTION
Hey,

The following causes a panic:

``` go
func TestConnection(t *testing.T) {
    t.Log("Testing connection...")
    conn := nsq.NewConn("localhost:4150", defaultConfig)
    id, err := conn.Connect()
    if err != nil {
        t.Fatal(err)
    }
    t.Log(id)
    time.Sleep(100 * time.Nanosecond)
    conn.Close()
    time.Sleep(100 * time.Nanosecond)
    t.Log("Success.")
    return
}
```

![screen shot 2014-06-21 at 6 49 25 pm](https://cloud.githubusercontent.com/assets/2940902/3350200/5e9f1dd8-f996-11e3-986d-87327f7f05cd.png)

There is (I presume) a race somewhere in Close(). If you sleep for long enough (a few microseconds), the panic doesn't occur.
