### PR TITLE
Improve TLS support

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -11,7 +11,14 @@ func TestConfigSet(t *testing.T) {
 		t.Error("No error when setting `tls_v1` to an invalid value")
 	}
 	if err := c.Set("tls_v1", true); err != nil {
-		t.Errorf("Error setting `tls_v1` config: %v", err)
+		t.Errorf("Error setting `tls_v1` config. %v", err)
+	}
+
+	if err := c.Set("tls-insecure-skip-verify", true); err != nil {
+		t.Errorf("Error setting `tls-insecure-skip-verify` config. %v", err)
+	}
+	if c.TlsConfig.InsecureSkipVerify != true {
+		t.Errorf("Error setting `tls-insecure-skip-verify` config: %v", c.TlsConfig)
 	}
 }
 

--- a/consumer.go
+++ b/consumer.go
@@ -205,7 +205,7 @@ func (r *Consumer) getMaxInFlight() int32 {
 // will allow in-flight, and updates all existing connections as appropriate.
 //
 // For example, ChangeMaxInFlight(0) would pause message flow
-// 
+//
 // If already connected, it updates the reader RDY state for each connection.
 func (r *Consumer) ChangeMaxInFlight(maxInFlight int) {
 	if r.getMaxInFlight() == int32(maxInFlight) {


### PR DESCRIPTION
We need to make a few changes to improve go-nsq support for TLS.

The default validation for TLS connections should be set to ServerName, and that should validate the broadcast_address used from lookupd, or the hostname of a direct nsqd connection against the certificate.

We also need to expose options for setting InsecureSkipVerify and the CA root so that they can be accessed via the config `Set(key, value)` interface.

cc: @mreiferson 
