### PR TITLE
configure session-specific msg_timeout

### DIFF
--- a/config.go
+++ b/config.go
@@ -97,6 +97,9 @@ type Config struct {
 	// Maximum amount of time to backoff when processing fails 0 == no backoff
 	MaxBackoffDuration time.Duration `opt:"max_backoff_duration" min:"0" max:"60m" default:"2m"`
 
+	// The server-side message timeout for messages delivered to this client
+	MsgTimeout time.Duration `opt:"msg_timeout" min:"0"`
+
 	// secret for nsqd authentication (requires nsqd 0.2.29+)
 	AuthSecret string `opt:"auth_secret"`
 }

--- a/conn.go
+++ b/conn.go
@@ -279,6 +279,7 @@ func (c *Conn) identify() (*IdentifyResponse, error) {
 	ci["sample_rate"] = c.config.SampleRate
 	ci["output_buffer_size"] = c.config.OutputBufferSize
 	ci["output_buffer_timeout"] = int64(c.config.OutputBufferTimeout / time.Millisecond)
+	ci["msg_timeout"] = int64(c.config.MsgTimeout / time.Millisecond)
 	cmd, err := Identify(ci)
 	if err != nil {
 		return nil, ErrIdentify{err.Error()}


### PR DESCRIPTION
any way to get at that initial identify call with the standard ConnectTo\* methods?

thanks!
