### PR TITLE
test against matrix of nsqd versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,19 @@ go:
   - 1.2.2
   - 1.3
 env:
-  - GOARCH=amd64
-  - GOARCH=386
+  - NSQ_DOWNLOAD=nsq-0.2.24.linux-amd64.go1.2 GOARCH=amd64
+  - NSQ_DOWNLOAD=nsq-0.2.24.linux-amd64.go1.2 GOARCH=386
+  - NSQ_DOWNLOAD=nsq-0.2.27.linux-amd64.go1.2 GOARCH=amd64
+  - NSQ_DOWNLOAD=nsq-0.2.27.linux-amd64.go1.2 GOARCH=386
+  - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 GOARCH=amd64
+  - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 GOARCH=386
 install:
   - go get github.com/bitly/go-simplejson
   - go get github.com/mreiferson/go-snappystream
 script:
-  - wget https://github.com/bitly/nsq/releases/download/v0.2.28/nsq-0.2.28.linux-amd64.go1.2.1.tar.gz
-  - tar zxvf nsq-0.2.28.linux-amd64.go1.2.1.tar.gz
-  - sudo cp nsq-0.2.28.linux-amd64.go1.2.1/bin/nsqd nsq-0.2.28.linux-amd64.go1.2.1/bin/nsqlookupd /usr/local/bin
+  - wget http://bitly-downloads.s3.amazonaws.com/nsq/$NSQ_DOWNLOAD.tar.gz
+  - tar zxvf $NSQ_DOWNLOAD.tar.gz
+  - sudo cp $NSQ_DOWNLOAD/bin/nsqd $NSQ_DOWNLOAD/bin/nsqlookupd /usr/local/bin
   - pushd $TRAVIS_BUILD_DIR
   - ./test.sh
   - popd


### PR DESCRIPTION
To match bitly/pynsq#67 we should add a matrix of nsqd versions to test against. This will ensure that we have backwards compatibility where we expect to.
