### PR TITLE
handle lookupd_http_address like pynsq

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -330,15 +330,15 @@ func (r *Consumer) nextLookupdEndpoint() string {
 	r.lookupdQueryIndex = (r.lookupdQueryIndex + 1) % num
 
 	urlString := addr
-	if !strings.Contains(urlString, "/") {
-		urlString = fmt.Sprintf("http://%s/", addr)
+	if !strings.Contains(urlString, "://") {
+		urlString = "http://" + addr
 	}
 
 	u, err := url.Parse(urlString)
 	if err != nil {
 		panic(err)
 	}
-	if u.Path == "/" {
+	if u.Path == "/" || u.Path == "" {
 		u.Path = "/lookup"
 	}
 


### PR DESCRIPTION
go-nsq would set the path /lookup only if the path was
"/", but not if the path was completely empty. pynsq
would also set the path /lookup if the path was completely empty.

cc @jehiah @mreiferson
