### PR TITLE
centralize logging and make it pluggable

### DIFF
--- a/delegates.go
+++ b/delegates.go
@@ -5,13 +5,40 @@ import "time"
 // LogLevel specifies the severity of a given log message
 type LogLevel int
 
-// logging levels
+type logger interface {
+	Output(calldepth int, s string) error
+}
+
+// logging constants
 const (
 	LogLevelDebug LogLevel = iota
 	LogLevelInfo
 	LogLevelWarning
 	LogLevelError
+
+	LogLevelDebugPrefix   = "DBG"
+	LogLevelInfoPrefix    = "INF"
+	LogLevelWarningPrefix = "WRN"
+	LogLevelErrorPrefix   = "ERR"
 )
+
+// LogPrefix Resolution
+func logPrefix(lvl LogLevel) string {
+	var prefix string
+
+	switch lvl {
+	case LogLevelDebug:
+		prefix = LogLevelDebugPrefix
+	case LogLevelInfo:
+		prefix = LogLevelInfoPrefix
+	case LogLevelWarning:
+		prefix = LogLevelWarningPrefix
+	case LogLevelError:
+		prefix = LogLevelErrorPrefix
+	}
+
+	return prefix
+}
 
 // MessageDelegate is an interface of methods that are used as
 // callbacks in Message


### PR DESCRIPTION
This request does two things, it centralizes logging to the `log.go` to remove some code duplication with respect to logging.  It also make the log an interface so that people can easily drop their own logging structures in.

The structure simply needs to implement the following methods:

``` go
    Debugf(format string, v ...interface{})
    Infof(format string, v ...interface{})
    Warnf(format string, v ...interface{})
    Errorf(format string, v ...interface{})
```
