### PR TITLE
producer: panic on error before first connection

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -214,17 +214,15 @@ func (w *Producer) connect() error {
 
 	w.log(LogLevelInfo, "(%s) connecting to nsqd", w.addr)
 
-	conn := NewConn(w.addr, &w.config, &producerConnDelegate{w})
-	conn.SetLogger(w.logger, w.logLvl, fmt.Sprintf("%3d (%%s)", w.id))
-
-	_, err := conn.Connect()
+	w.conn = NewConn(w.addr, &w.config, &producerConnDelegate{w})
+	w.conn.SetLogger(w.logger, w.logLvl, fmt.Sprintf("%3d (%%s)", w.id))
+	_, err := w.conn.Connect()
 	if err != nil {
-		conn.Close()
+		w.conn.Close()
 		w.log(LogLevelError, "(%s) error connecting to nsqd - %s", w.addr, err)
 		atomic.StoreInt32(&w.state, StateInit)
 		return err
 	}
-	w.conn = conn
 
 	w.wg.Add(1)
 	go w.router()


### PR DESCRIPTION
from #78

```
goroutine 24 [running]:
runtime.panic(0x71e9c0, 0x926eb3)
    /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/bitly/go-nsq.(*Conn).Close(0x0, 0x0, 0x0)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/conn.go:175 +0xcb
github.com/bitly/go-nsq.(*Producer).close(0xc208102000)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/producer.go:239 +0x88
github.com/bitly/go-nsq.(*Producer).onConnIOError(0xc208102000, 0xc2080bcd80, 0x7f13c7b59da0, 0xc208100240)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/producer.go:327 +0x27
github.com/bitly/go-nsq.(*producerConnDelegate).OnIOError(0xc208032138, 0xc2080bcd80, 0x7f13c7b59da0, 0xc208100240)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/delegates.go:141 +0x48
github.com/bitly/go-nsq.(*Conn).WriteCommand(0xc2080bcd80, 0xc2080d1c70, 0x0, 0x0)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/conn.go:254 +0x1e7
github.com/bitly/go-nsq.(*Conn).identify(0xc2080bcd80, 0x920248, 0x0, 0x0)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/conn.go:293 +0xa1e
github.com/bitly/go-nsq.(*Conn).Connect(0xc2080bcd80, 0x9, 0x0, 0x0)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/conn.go:149 +0x346
github.com/bitly/go-nsq.(*Producer).connect(0xc208102000, 0x0, 0x0)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/producer.go:220 +0x3f4
github.com/bitly/go-nsq.(*Producer).sendCommandAsync(0xc208102000, 0xc2080d1b30, 0xc20811bc80, 0x0, 0x0, 0x0, 0x0, 0x0)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/producer.go:182 +0xd7
github.com/bitly/go-nsq.(*Producer).sendCommand(0xc208102000, 0xc2080d1b30, 0x0, 0x0)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/producer.go:165 +0x78
github.com/bitly/go-nsq.(*Producer).Publish(0xc208102000, 0x778bd0, 0x9, 0xc2080bca20, 0x105, 0x116, 0x0, 0x0)
    /mnt/hgfs/twmb/dev/go/src/github.com/bitly/go-nsq/producer.go:150 +0x16f
```
