### PR TITLE
consumer: expose message Source

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -496,6 +496,7 @@ func (c *Conn) readLoop() {
 				goto exit
 			}
 			msg.Delegate = delegate
+			msg.NSQDAddress = c.String()
 
 			atomic.AddInt64(&c.rdyCount, -1)
 			atomic.AddInt64(&c.messagesInFlight, 1)

--- a/message.go
+++ b/message.go
@@ -23,6 +23,8 @@ type Message struct {
 	Timestamp int64
 	Attempts  uint16
 
+	NSQDAddress string
+
 	Delegate MessageDelegate
 
 	autoResponseDisabled int32


### PR DESCRIPTION
open for discussion - this is one (simple) way to expose the source
nsqd that delivered the message.

in my case, I used this to remove a head-of-line blocking issue
where a single bad actor was preventing an application from making
progress.
