### PR TITLE
make #ephemeral topic names valid to match nsq changes

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -20,23 +20,23 @@ const (
 	FrameTypeMessage  int32 = 2
 )
 
-var validTopicNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+$`)
-var validChannelNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+(#ephemeral)?$`)
+var validTopicChannelNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+(#ephemeral)?$`)
 
 // IsValidTopicName checks a topic name for correctness
 func IsValidTopicName(name string) bool {
-	if len(name) > 64 || len(name) < 1 {
-		return false
-	}
-	return validTopicNameRegex.MatchString(name)
+	return isValidName(name)
 }
 
 // IsValidChannelName checks a channel name for correctness
 func IsValidChannelName(name string) bool {
+	return isValidName(name)
+}
+
+func isValidName(name string) bool {
 	if len(name) > 64 || len(name) < 1 {
 		return false
 	}
-	return validChannelNameRegex.MatchString(name)
+	return validTopicChannelNameRegex.MatchString(name)
 }
 
 // ReadResponse is a client-side utility function to read from the supplied Reader


### PR DESCRIPTION
Simple pull request to support #ephemeral topic names which were recently added to nsqd: https://github.com/bitly/nsq/pull/305

Changes mirror changes to https://github.com/bitly/nsq/blob/master/util/names.go
