### PR TITLE
Add a tcp no delay option

### DIFF
--- a/config.go
+++ b/config.go
@@ -104,6 +104,10 @@ type Config struct {
 	ReadTimeout  time.Duration `opt:"read_timeout" min:"100ms" max:"5m" default:"60s"`
 	WriteTimeout time.Duration `opt:"write_timeout" min:"100ms" max:"5m" default:"1s"`
 
+	// Delay packet transmission in hopes of sending fewer packets if TcpNoDelay is false.
+	// In consumer sence, it may improve throughput with FIN feedback.
+	TcpNoDelay bool `opt:"tcp_no_delay" default:"true"`
+
 	// LocalAddr is the local address to use when dialing an nsqd.
 	// If empty, a local address is automatically chosen.
 	LocalAddr net.Addr `opt:"local_addr"`

--- a/conn.go
+++ b/conn.go
@@ -150,6 +150,7 @@ func (c *Conn) Connect() (*IdentifyResponse, error) {
 		return nil, err
 	}
 	c.conn = conn.(*net.TCPConn)
+	c.conn.SetNoDelay(c.config.TcpNoDelay)
 	c.r = conn
 	c.w = conn
 


### PR DESCRIPTION
For a consumer to `nsqd`, each messages will sent `FIN` to `nsqd` if it processes successfully.  
I bench test consumer 10k message per second, the Ethernet is overhead by trigger too much interrupt requests to it(about 15k/s), and got very high(40%) hiq cpu usage. 
When I turn off the tcpNoDelay, the interrupts per second decrease to about 10k/s and the performance has improved.
ps: Loopback may not trigger high hiq cpu usage, but the performance is still improved.