### PR TITLE
TestProducerConnection fails using 127.0.0.2, works with 127.0.0.1

### DIFF
--- a/producer_test.go
+++ b/producer_test.go
@@ -42,7 +42,7 @@ func (h *ConsumerHandler) HandleMessage(message *Message) error {
 
 func TestProducerConnection(t *testing.T) {
 	config := NewConfig()
-	laddr := "127.0.0.2"
+	laddr := "127.0.0.1"
 
 	config.LocalAddr, _ = net.ResolveTCPAddr("tcp", laddr+":0")
 


### PR DESCRIPTION
I pulled to latest go-nsq, and find that when running test.sh, the TestProducerConnection fails. I'm on OSX 10.10.2, go 1.5.1, nsqd v0.3.6-alpha (built w/go1.5.1).

~~~
=== RUN   TestProducerConnection
--- FAIL: TestProducerConnection (0.00s)
        producer_test.go:54: should lazily connect - dial tcp 127.0.0.2:0->127.0.0.1:4150: bind: can't assign requested address

~~~

I'm not sure why the code expects to be able to bind 127.0.0.2, but if it was a typo, then this PR will fix and make the tests all green again.