### PR TITLE
TestProducerConnection() now green on OSX. fixes #161.

### DIFF
--- a/producer_test.go
+++ b/producer_test.go
@@ -42,7 +42,7 @@ func (h *ConsumerHandler) HandleMessage(message *Message) error {
 
 func TestProducerConnection(t *testing.T) {
 	config := NewConfig()
-	laddr := "127.0.0.2"
+	laddr := "127.0.0.1"
 
 	config.LocalAddr, _ = net.ResolveTCPAddr("tcp", laddr+":0")
 


### PR DESCRIPTION
per discussion in https://github.com/nsqio/go-nsq/issues/161, this makes the TestProducerConnection() test (and now all tests) green on OSX.