### PR TITLE
DecodeMessage: skip bytes Buffer, reducing alloc overhead

### DIFF
--- a/message.go
+++ b/message.go
@@ -139,10 +139,19 @@ func (m *Message) WriteTo(w io.Writer) (int64, error) {
 }
 
 // DecodeMessage deserializes data (as []byte) and creates a new Message
+// message format:
+// [x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x][x]...
+// |       (int64)        ||    ||      (hex string encoded in ASCII)           || (binary)
+// |       8-byte         ||    ||                 16-byte                      || N-byte
+// ------------------------------------------------------------------------------------------...
+//   nanosecond timestamp    ^^                   message ID                       message body
+//                        (uint16)
+//                         2-byte
+//                        attempts
 func DecodeMessage(b []byte) (*Message, error) {
 	var msg Message
 
-	if len(b) < 11+MsgIDLength {
+	if len(b) < 10+MsgIDLength {
 		return nil, errors.New("not enough data to decode valid message")
 	}
 


### PR DESCRIPTION
see https://github.com/nsqio/go-nsq/issues/174#issuecomment-210256321
for more discussion and before and after