### PR TITLE
expose cmd of struct ProducerTransaction

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -63,6 +63,10 @@ func (t *ProducerTransaction) finish() {
 	}
 }
 
+func (t *ProducerTransaction) Cmd() *Command {
+	return t.cmd
+}
+
 // NewProducer returns an instance of Producer for the specified address
 //
 // The only valid way to create a Config is via NewConfig, using a struct literal will panic.


### PR DESCRIPTION
if PublishAsync return error, I need to know which Command cause error, so it's better expose cmd of struct ProducerTransaction.