### PR TITLE
fix producer Stop() EOF

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -479,7 +479,11 @@ func (c *Conn) readLoop() {
 		}
 
 		frameType, data, err := ReadUnpackedResponse(c)
+
 		if err != nil {
+			if err == io.EOF && atomic.LoadInt32(&c.closeFlag) == 1 {
+				goto exit
+			}
 			if !strings.Contains(err.Error(), "use of closed network connection") {
 				c.log(LogLevelError, "IO error - %s", err)
 				c.delegate.OnIOError(c, err)


### PR DESCRIPTION
when producer.Stop() EOF exception occur

```

2016/12/01 09:44:47 ERR  3856 (10.160.3.70:4150) IO error - EOF
2016/12/01 09:44:47 INF  3856 (10.160.3.70:4150) beginning close
2016/12/01 09:44:47 INF  3856 (10.160.3.70:4150) readLoop exiting
2016/12/01 09:44:47 INF  3856 (10.160.3.70:4150) breaking out of writeLoop
2016/12/01 09:44:47 INF  3856 (10.160.3.70:4150) writeLoop exiting
2016/12/01 09:44:47 INF  3856 stopping
2016/12/01 09:44:47 INF  3856 exiting router

```