### PR TITLE
logging: fix 'backing off for x' message formatting

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -802,8 +802,8 @@ func (r *Consumer) startStopContinueBackoff(conn *Conn, signal backoffSignal) {
 			backoffDuration = r.config.MaxBackoffDuration
 		}
 
-		r.log(LogLevelWarning, "backing off for %.04f seconds (backoff level %d), setting all to RDY 0",
-			backoffDuration.Seconds(), backoffCounter)
+		r.log(LogLevelWarning, "backing off for %s (backoff level %d), setting all to RDY 0",
+			backoffDuration, backoffCounter)
 
 		// send RDY 0 immediately (to *all* connections)
 		for _, c := range r.conns() {
@@ -829,7 +829,7 @@ func (r *Consumer) resume() {
 	conns := r.conns()
 	if len(conns) == 0 {
 		r.log(LogLevelWarning, "no connection available to resume")
-		r.log(LogLevelWarning, "backing off for %.04f seconds", 1)
+		r.log(LogLevelWarning, "backing off for %s", time.Second)
 		r.backoff(time.Second)
 		return
 	}
@@ -846,7 +846,7 @@ func (r *Consumer) resume() {
 	err := r.updateRDY(choice, 1)
 	if err != nil {
 		r.log(LogLevelWarning, "(%s) error resuming RDY 1 - %s", choice.String(), err)
-		r.log(LogLevelWarning, "backing off for %.04f seconds", 1)
+		r.log(LogLevelWarning, "backing off for %s", time.Second)
 		r.backoff(time.Second)
 		return
 	}


### PR DESCRIPTION
I noticed the following in my logs recently

```
2016/12/22 15:05:27 consumer.go:844: WRN    1 [chaunceys_log/notificationsd] backing off for %!f(int=0001) seconds
```

This fixes related messages to always use `%s` for time.Duration types for backoff log messages.

RFR @mreiferson