### PR TITLE
Fix CS

### DIFF
--- a/config_flag.go
+++ b/config_flag.go
@@ -6,7 +6,7 @@ import (
 
 // ConfigFlag wraps a Config and implements the flag.Value interface
 type ConfigFlag struct {
-	*Config
+	Config *Config
 }
 
 // Set takes a comma separated value and follows the rules in Config.Set


### PR DESCRIPTION
```
> go vet config_flag_test.go
config_flag_test.go:13: github.com/nsqio/go-nsq.ConfigFlag composite literal uses unkeyed fields
```