### PR TITLE
make query nsqlookupd dail timeout configurable

### DIFF
--- a/api_request.go
+++ b/api_request.go
@@ -46,8 +46,8 @@ type wrappedResp struct {
 }
 
 // stores the result in the value pointed to by ret(must be a pointer)
-func apiRequestNegotiateV1(method string, endpoint string, body io.Reader, ret interface{}) error {
-	httpclient := &http.Client{Transport: newDeadlineTransport(2 * time.Second)}
+func apiRequestNegotiateV1(method string, endpoint string, body io.Reader, timeout time.Duration, ret interface{}) error {
+	httpclient := &http.Client{Transport: newDeadlineTransport(timeout * time.Second)}
 	req, err := http.NewRequest(method, endpoint, body)
 	if err != nil {
 		return err

--- a/api_request.go
+++ b/api_request.go
@@ -47,7 +47,7 @@ type wrappedResp struct {
 
 // stores the result in the value pointed to by ret(must be a pointer)
 func apiRequestNegotiateV1(method string, endpoint string, body io.Reader, timeout time.Duration, ret interface{}) error {
-	httpclient := &http.Client{Transport: newDeadlineTransport(timeout * time.Second)}
+	httpclient := &http.Client{Transport: newDeadlineTransport(timeout)}
 	req, err := http.NewRequest(method, endpoint, body)
 	if err != nil {
 		return err

--- a/consumer.go
+++ b/consumer.go
@@ -462,7 +462,7 @@ retry:
 	r.log(LogLevelInfo, "querying nsqlookupd %s", endpoint)
 
 	var data lookupResp
-	err := apiRequestNegotiateV1("GET", endpoint, nil, &data)
+	err := apiRequestNegotiateV1("GET", endpoint, nil, r.config.DialTimeout, &data)
 	if err != nil {
 		r.log(LogLevelError, "error querying nsqlookupd (%s) - %s", endpoint, err)
 		retries++


### PR DESCRIPTION
when network is not well, 2 seconds may not be able dail success.
Use nsq.Config.DialTimeout  to configure this parameter