### PR TITLE
feat(producer): avoid sending duplicate data

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -342,12 +342,19 @@ func (w *Producer) popTransaction(frameType int32, data []byte) {
 }
 
 func (w *Producer) transactionCleanup() {
-	// clean up transactions we can easily account for
-	for _, t := range w.transactions {
-		t.Error = ErrNotConnected
-		t.finish()
+	for {
+		select {
+		case data := <-w.responseChan:
+			w.popTransaction(FrameTypeResponse, data)
+		default:
+			// clean up transactions we can easily account for
+			for _, t := range w.transactions {
+				t.Error = ErrNotConnected
+				t.finish()
+			}
+			w.transactions = w.transactions[:0]
+		}
 	}
-	w.transactions = w.transactions[:0]
 
 	// spin and free up any writes that might have raced
 	// with the cleanup process (blocked on writing


### PR DESCRIPTION
``` go
for {
	select {
	case t := <-w.transactionChan:
		w.transactions = append(w.transactions, t)
		err := w.conn.WriteCommand(t.cmd)
		if err != nil {
			w.log(LogLevelError, "(%s) sending command - %s", w.conn.String(), err)
			w.close()
		}
	case data := <-w.responseChan:
		w.popTransaction(FrameTypeResponse, data)
	case data := <-w.errorChan:
		w.popTransaction(FrameTypeError, data)
	case <-w.closeChan:
		goto exit
	case <-w.exitChan:
		goto exit
	}
}
```

after producer called Stop, there may be data in channal w.responseChan,  and exitChan may has been closed, and select randomly selected goto exit. 

then in 

``` go
func (w *Producer) transactionCleanup() {
	// clean up transactions we can easily account for
	for _, t := range w.transactions {
		t.Error = ErrNotConnected
		t.finish()
	}
	w.transactions = w.transactions[:0]
	... ...
}
```
if we don't read responseChan, the successfully sent data may be send again after creating a new producer and publish again. 