### PR TITLE
consumer: update RDY when setting MaxInFlight to 0 (pause consumer)

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -884,7 +884,7 @@ func (r *Consumer) maybeUpdateRDY(conn *Conn) {
 	count := r.perConnMaxInFlight()
 
 	// refill when at 1, or at 25%, or if connections have changed and we're imbalanced
-	if remain <= 1 || remain < (lastRdyCount/4) || (count > 0 && count < remain) {
+	if remain <= 1 || remain < (lastRdyCount/4) || (count > 0 && count < remain) || r.getMaxInFlight() == 0 {
 		r.log(LogLevelDebug, "(%s) sending RDY %d (%d remain from last RDY %d)",
 			conn, count, remain, lastRdyCount)
 		r.updateRDY(conn, count)

--- a/consumer.go
+++ b/consumer.go
@@ -884,7 +884,7 @@ func (r *Consumer) maybeUpdateRDY(conn *Conn) {
 	count := r.perConnMaxInFlight()
 
 	// refill when at 1, or at 25%, or if connections have changed and we're imbalanced
-	if remain <= 1 || remain < (lastRdyCount/4) || (count > 0 && count < remain) || r.getMaxInFlight() == 0 {
+	if remain <= 1 || remain < (lastRdyCount/4) || count < remain {
 		r.log(LogLevelDebug, "(%s) sending RDY %d (%d remain from last RDY %d)",
 			conn, count, remain, lastRdyCount)
 		r.updateRDY(conn, count)


### PR DESCRIPTION
When trying to pause the consumer via MaxInFlight 0, updateRDY is not called as maybeUpdateRDY checks for "count > 0". This PR removes that check from the condition.

Now I'm not sure if there's a legitimate reason for not updating RDY when MaxInFlight is 0, but right now the code breaks the "pause consumer" use case.