### PR TITLE
make getLogger public

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -223,7 +223,7 @@ func (r *Consumer) SetLogger(l logger, lvl LogLevel) {
 	r.logLvl = lvl
 }
 
-func (r *Consumer) getLogger() (logger, LogLevel) {
+func (r *Consumer) GetLogger() (logger, LogLevel) {
 	r.logGuard.RLock()
 	defer r.logGuard.RUnlock()
 
@@ -523,7 +523,7 @@ func (r *Consumer) ConnectToNSQD(addr string) error {
 
 	atomic.StoreInt32(&r.connectedFlag, 1)
 
-	logger, logLvl := r.getLogger()
+	logger, logLvl := r.GetLogger()
 
 	conn := NewConn(addr, &r.config, &consumerConnDelegate{r})
 	conn.SetLogger(logger, logLvl,
@@ -1162,7 +1162,7 @@ func (r *Consumer) exit() {
 }
 
 func (r *Consumer) log(lvl LogLevel, line string, args ...interface{}) {
-	logger, logLvl := r.getLogger()
+	logger, logLvl := r.GetLogger()
 
 	if logger == nil {
 		return


### PR DESCRIPTION
This PR will make `getLogger` public. 

For now, 
* there is no way to get currently used logger instance
* there is no way to just set the log level

With `getLogger` being public, we can easily resolve the above two problems.
> there is no way to get currently used logger instance

`GetLogger()` will return log instance and log level

> there is no way to just set the log level
```
logger, _ := consumer.GetLogger()
consumer.SetLogger(logger, LogLevelDebug)

```