### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/config.go
+++ b/config.go
@@ -255,7 +255,7 @@ func (c *Config) setDefaults() error {
 
 type structTagsConfig struct{}
 
-// Handle options that are listed in StructTags
+// HandlesOption handles options that are listed in StructTags
 func (h *structTagsConfig) HandlesOption(c *Config, option string) bool {
 	val := reflect.ValueOf(c).Elem()
 	typ := val.Type()


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._