### PR TITLE
check response message size is positive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.10.x
   - 1.11.x
   - 1.12.x
+  - 1.13.x
 env:
   - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 GOARCH=amd64
   - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 GOARCH=386

--- a/protocol.go
+++ b/protocol.go
@@ -3,6 +3,7 @@ package nsq
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"regexp"
 )
@@ -56,6 +57,9 @@ func ReadResponse(r io.Reader) ([]byte, error) {
 		return nil, err
 	}
 
+	if msgSize < 0 {
+		return nil, fmt.Errorf("response msg size is negative: %v", msgSize)
+	}
 	// message binary data
 	buf := make([]byte, msgSize)
 	_, err = io.ReadFull(r, buf)


### PR DESCRIPTION
This PR adds pre check for msg size before `make` a slice. 

We have encountered a panic in `make([]byte, msgSize)` with `panic: runtime error: makeslice: len out of range`. We have bounded the max message size by 20MB. So, it seems that make function should not panic. 

I have test that when `make` with a negative length, `make` will panic with `panic: runtime error: makeslice: len out of range`.