### PR TITLE
remove duplicate 'Config.assertInitialized()' check

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -145,8 +145,6 @@ type Consumer struct {
 // The only valid way to create a Config is via NewConfig, using a struct literal will panic.
 // After Config is passed into NewConsumer the values are no longer mutable (they are copied).
 func NewConsumer(topic string, channel string, config *Config) (*Consumer, error) {
-	config.assertInitialized()
-
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}

--- a/producer.go
+++ b/producer.go
@@ -70,7 +70,6 @@ func (t *ProducerTransaction) finish() {
 // The only valid way to create a Config is via NewConfig, using a struct literal will panic.
 // After Config is passed into NewProducer the values are no longer mutable (they are copied).
 func NewProducer(addr string, config *Config) (*Producer, error) {
-	config.assertInitialized()
 	err := config.Validate()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```c.assertInitialized()```  is executed twice both in  ``` NewProducer() / NewConsumer() ```  and ```config.Validate()``` 


