### PR TITLE
Expose interfaces to public API to ease testing

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -73,8 +73,8 @@ const (
 )
 
 type Consumer interface {
-	ConnEventsHandler
-	ConnEventsMessageHandler
+	connEventsHandler
+	connEventsMessageHandler
 
 	SetLogger(l logger, lvl LogLevel)
 	SetLoggerLevel(lvl LogLevel)
@@ -190,7 +190,7 @@ func NewConsumer(topic string, channel string, config *Config) (Consumer, error)
 		channel: channel,
 		config:  *config,
 
-		loggerCarrier: NewDefaultLoggerCarrier(),
+		loggerCarrier: newDefaultLoggerCarrier(),
 		maxInFlight:   int32(config.MaxInFlight),
 
 		incomingMessages: make(chan *Message),
@@ -288,7 +288,7 @@ func (c *nsqConsumer) perConnMaxInFlight() int64 {
 func (c *nsqConsumer) IsStarved() bool {
 	for _, conn := range c.conns() {
 		threshold := int64(float64(conn.RDY()) * 0.85)
-		inFlight := atomic.LoadInt64(conn.GetInflightMessageCount())
+		inFlight := atomic.LoadInt64(conn.getInflightMessageCount())
 		if inFlight >= threshold && inFlight > 0 && !conn.IsClosing() {
 			return true
 		}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -18,7 +18,7 @@ import (
 
 type MyTestHandler struct {
 	t                *testing.T
-	q                *Consumer
+	q                Consumer
 	messagesSent     int
 	messagesReceived int
 	messagesFailed   int
@@ -206,7 +206,7 @@ func consumerTest(t *testing.T, cb func(c *Config)) {
 		t.Fatal("should be able to disconnect from an nsqd - " + err.Error())
 	}
 
-	<-q.StopChan
+	<-q.GetStopChan()
 
 	stats = q.Stats()
 	if stats.Connections != 0 {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -187,8 +187,8 @@ func consumerTest(t *testing.T, cb func(c *Config)) {
 	}
 
 	conn := q.conns()[0]
-	if !strings.HasPrefix(conn.conn.LocalAddr().String(), laddr) {
-		t.Fatal("connection should be bound to the specified address:", conn.conn.LocalAddr())
+	if !strings.HasPrefix(conn.GetUnderlyingTCPConn().LocalAddr().String(), laddr) {
+		t.Fatal("connection should be bound to the specified address:", conn.GetUnderlyingTCPConn().LocalAddr())
 	}
 
 	err = q.DisconnectFromNSQD("1.2.3.4:4150")

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -187,8 +187,8 @@ func consumerTest(t *testing.T, cb func(c *Config)) {
 	}
 
 	conn := q.conns()[0]
-	if !strings.HasPrefix(conn.GetUnderlyingTCPConn().LocalAddr().String(), laddr) {
-		t.Fatal("connection should be bound to the specified address:", conn.GetUnderlyingTCPConn().LocalAddr())
+	if !strings.HasPrefix(conn.getUnderlyingTCPConn().LocalAddr().String(), laddr) {
+		t.Fatal("connection should be bound to the specified address:", conn.getUnderlyingTCPConn().LocalAddr())
 	}
 
 	err = q.DisconnectFromNSQD("1.2.3.4:4150")

--- a/delegates.go
+++ b/delegates.go
@@ -76,7 +76,7 @@ type ConnDelegate interface {
 // keeps the exported Consumer struct clean of the exported methods
 // required to implement the ConnDelegate interface
 type consumerConnDelegate struct {
-	r *Consumer
+	r Consumer
 }
 
 func (d *consumerConnDelegate) OnResponse(c Conn, data []byte) { d.r.onConnResponse(c, data) }

--- a/delegates.go
+++ b/delegates.go
@@ -2,35 +2,6 @@ package nsq
 
 import "time"
 
-type logger interface {
-	Output(calldepth int, s string) error
-}
-
-// LogLevel specifies the severity of a given log message
-type LogLevel int
-
-// Log levels
-const (
-	LogLevelDebug LogLevel = iota
-	LogLevelInfo
-	LogLevelWarning
-	LogLevelError
-	LogLevelMax = iota - 1 // convenience - match highest log level
-)
-
-// String returns the string form for a given LogLevel
-func (lvl LogLevel) String() string {
-	switch lvl {
-	case LogLevelInfo:
-		return "INF"
-	case LogLevelWarning:
-		return "WRN"
-	case LogLevelError:
-		return "ERR"
-	}
-	return "DBG"
-}
-
 // MessageDelegate is an interface of methods that are used as
 // callbacks in Message
 type MessageDelegate interface {
@@ -48,58 +19,58 @@ type MessageDelegate interface {
 }
 
 type connMessageDelegate struct {
-	c *Conn
+	c Conn
 }
 
-func (d *connMessageDelegate) OnFinish(m *Message) { d.c.onMessageFinish(m) }
-func (d *connMessageDelegate) OnRequeue(m *Message, t time.Duration, b bool) {
+func (d connMessageDelegate) OnFinish(m *Message) { d.c.onMessageFinish(m) }
+func (d connMessageDelegate) OnRequeue(m *Message, t time.Duration, b bool) {
 	d.c.onMessageRequeue(m, t, b)
 }
-func (d *connMessageDelegate) OnTouch(m *Message) { d.c.onMessageTouch(m) }
+func (d connMessageDelegate) OnTouch(m *Message) { d.c.onMessageTouch(m) }
 
 // ConnDelegate is an interface of methods that are used as
 // callbacks in Conn
 type ConnDelegate interface {
 	// OnResponse is called when the connection
 	// receives a FrameTypeResponse from nsqd
-	OnResponse(*Conn, []byte)
+	OnResponse(Conn, []byte)
 
 	// OnError is called when the connection
 	// receives a FrameTypeError from nsqd
-	OnError(*Conn, []byte)
+	OnError(Conn, []byte)
 
 	// OnMessage is called when the connection
 	// receives a FrameTypeMessage from nsqd
-	OnMessage(*Conn, *Message)
+	OnMessage(Conn, *Message)
 
 	// OnMessageFinished is called when the connection
 	// handles a FIN command from a message handler
-	OnMessageFinished(*Conn, *Message)
+	OnMessageFinished(Conn, *Message)
 
 	// OnMessageRequeued is called when the connection
 	// handles a REQ command from a message handler
-	OnMessageRequeued(*Conn, *Message)
+	OnMessageRequeued(Conn, *Message)
 
 	// OnBackoff is called when the connection triggers a backoff state
-	OnBackoff(*Conn)
+	OnBackoff(Conn)
 
 	// OnContinue is called when the connection finishes a message without adjusting backoff state
-	OnContinue(*Conn)
+	OnContinue(Conn)
 
 	// OnResume is called when the connection triggers a resume state
-	OnResume(*Conn)
+	OnResume(Conn)
 
 	// OnIOError is called when the connection experiences
 	// a low-level TCP transport error
-	OnIOError(*Conn, error)
+	OnIOError(Conn, error)
 
 	// OnHeartbeat is called when the connection
 	// receives a heartbeat from nsqd
-	OnHeartbeat(*Conn)
+	OnHeartbeat(Conn)
 
 	// OnClose is called when the connection
 	// closes, after all cleanup
-	OnClose(*Conn)
+	OnClose(Conn)
 }
 
 // keeps the exported Consumer struct clean of the exported methods
@@ -108,32 +79,36 @@ type consumerConnDelegate struct {
 	r *Consumer
 }
 
-func (d *consumerConnDelegate) OnResponse(c *Conn, data []byte)       { d.r.onConnResponse(c, data) }
-func (d *consumerConnDelegate) OnError(c *Conn, data []byte)          { d.r.onConnError(c, data) }
-func (d *consumerConnDelegate) OnMessage(c *Conn, m *Message)         { d.r.onConnMessage(c, m) }
-func (d *consumerConnDelegate) OnMessageFinished(c *Conn, m *Message) { d.r.onConnMessageFinished(c, m) }
-func (d *consumerConnDelegate) OnMessageRequeued(c *Conn, m *Message) { d.r.onConnMessageRequeued(c, m) }
-func (d *consumerConnDelegate) OnBackoff(c *Conn)                     { d.r.onConnBackoff(c) }
-func (d *consumerConnDelegate) OnContinue(c *Conn)                    { d.r.onConnContinue(c) }
-func (d *consumerConnDelegate) OnResume(c *Conn)                      { d.r.onConnResume(c) }
-func (d *consumerConnDelegate) OnIOError(c *Conn, err error)          { d.r.onConnIOError(c, err) }
-func (d *consumerConnDelegate) OnHeartbeat(c *Conn)                   { d.r.onConnHeartbeat(c) }
-func (d *consumerConnDelegate) OnClose(c *Conn)                       { d.r.onConnClose(c) }
+func (d *consumerConnDelegate) OnResponse(c Conn, data []byte) { d.r.onConnResponse(c, data) }
+func (d *consumerConnDelegate) OnError(c Conn, data []byte)    { d.r.onConnError(c, data) }
+func (d *consumerConnDelegate) OnMessage(c Conn, m *Message)   { d.r.onConnMessage(c, m) }
+func (d *consumerConnDelegate) OnMessageFinished(c Conn, m *Message) {
+	d.r.onConnMessageFinished(c, m)
+}
+func (d *consumerConnDelegate) OnMessageRequeued(c Conn, m *Message) {
+	d.r.onConnMessageRequeued(c, m)
+}
+func (d *consumerConnDelegate) OnBackoff(c Conn)            { d.r.onConnBackoff(c) }
+func (d *consumerConnDelegate) OnContinue(c Conn)           { d.r.onConnContinue(c) }
+func (d *consumerConnDelegate) OnResume(c Conn)             { d.r.onConnResume(c) }
+func (d *consumerConnDelegate) OnIOError(c Conn, err error) { d.r.onConnIOError(c, err) }
+func (d *consumerConnDelegate) OnHeartbeat(c Conn)          { d.r.onConnHeartbeat(c) }
+func (d *consumerConnDelegate) OnClose(c Conn)              { d.r.onConnClose(c) }
 
 // keeps the exported Producer struct clean of the exported methods
 // required to implement the ConnDelegate interface
 type producerConnDelegate struct {
-	w *Producer
+	w Producer
 }
 
-func (d *producerConnDelegate) OnResponse(c *Conn, data []byte)       { d.w.onConnResponse(c, data) }
-func (d *producerConnDelegate) OnError(c *Conn, data []byte)          { d.w.onConnError(c, data) }
-func (d *producerConnDelegate) OnMessage(c *Conn, m *Message)         {}
-func (d *producerConnDelegate) OnMessageFinished(c *Conn, m *Message) {}
-func (d *producerConnDelegate) OnMessageRequeued(c *Conn, m *Message) {}
-func (d *producerConnDelegate) OnBackoff(c *Conn)                     {}
-func (d *producerConnDelegate) OnContinue(c *Conn)                    {}
-func (d *producerConnDelegate) OnResume(c *Conn)                      {}
-func (d *producerConnDelegate) OnIOError(c *Conn, err error)          { d.w.onConnIOError(c, err) }
-func (d *producerConnDelegate) OnHeartbeat(c *Conn)                   { d.w.onConnHeartbeat(c) }
-func (d *producerConnDelegate) OnClose(c *Conn)                       { d.w.onConnClose(c) }
+func (d *producerConnDelegate) OnResponse(c Conn, data []byte)       { d.w.onConnResponse(c, data) }
+func (d *producerConnDelegate) OnError(c Conn, data []byte)          { d.w.onConnError(c, data) }
+func (d *producerConnDelegate) OnMessage(c Conn, m *Message)         {}
+func (d *producerConnDelegate) OnMessageFinished(c Conn, m *Message) {}
+func (d *producerConnDelegate) OnMessageRequeued(c Conn, m *Message) {}
+func (d *producerConnDelegate) OnBackoff(c Conn)                     {}
+func (d *producerConnDelegate) OnContinue(c Conn)                    {}
+func (d *producerConnDelegate) OnResume(c Conn)                      {}
+func (d *producerConnDelegate) OnIOError(c Conn, err error)          { d.w.onConnIOError(c, err) }
+func (d *producerConnDelegate) OnHeartbeat(c Conn)                   { d.w.onConnHeartbeat(c) }
+func (d *producerConnDelegate) OnClose(c Conn)                       { d.w.onConnClose(c) }

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,151 @@
+package nsq
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+)
+
+type LoggerCarrier interface {
+	GetLogLevel() LogLevel
+	GetLoggers() []logger
+	SetLogger(l logger, lvl LogLevel, format string)
+	SetLoggerForLevel(l logger, lvl LogLevel, format string)
+	SetLoggerLevel(lvl LogLevel)
+	Log(lvl LogLevel, line string, addr string, args ...interface{})
+}
+
+type DefaultLoggerCarrier struct {
+	LoggerCarrier
+
+	logger []logger
+	logLvl LogLevel
+	logFmt []string
+
+	logGuard sync.RWMutex
+}
+
+func NewDefaultLoggerCarrier() LoggerCarrier {
+	carrier := &DefaultLoggerCarrier{
+		logger: make([]logger, int(LogLevelMax+1)),
+		logLvl: LogLevelInfo,
+		logFmt: make([]string, LogLevelMax+1),
+	}
+
+	l := log.New(os.Stderr, "", log.Flags())
+	for index := range carrier.logger {
+		carrier.logger[index] = l
+	}
+
+	return carrier
+}
+
+// SetLogger assigns the logger to use as well as a level
+//
+// The logger parameter is an interface that requires the following
+// method to be implemented (such as the the stdlib log.Logger):
+//
+//    Output(calldepth int, s string)
+//
+func (c *DefaultLoggerCarrier) SetLogger(l logger, lvl LogLevel, format string) {
+	c.logGuard.Lock()
+	defer c.logGuard.Unlock()
+
+	if format == "" {
+		format = "(%s)"
+	}
+	for level := range c.logger {
+		c.logger[level] = l
+		c.logFmt[level] = format
+	}
+	c.logLvl = lvl
+}
+
+func (c *DefaultLoggerCarrier) SetLoggerForLevel(l logger, lvl LogLevel, format string) {
+	c.logGuard.Lock()
+	defer c.logGuard.Unlock()
+
+	if format == "" {
+		format = "(%s)"
+	}
+	c.logger[lvl] = l
+	c.logFmt[lvl] = format
+}
+
+func (c *DefaultLoggerCarrier) SetLoggerLevel(lvl LogLevel) {
+	c.logGuard.Lock()
+	defer c.logGuard.Unlock()
+
+	c.logLvl = lvl
+}
+
+func (c *DefaultLoggerCarrier) GetLoggers() []logger {
+	c.logGuard.RLock()
+	defer c.logGuard.RUnlock()
+
+	return c.logger
+}
+
+func (c *DefaultLoggerCarrier) GetLogLevel() LogLevel {
+	c.logGuard.RLock()
+	defer c.logGuard.RUnlock()
+
+	return c.logLvl
+}
+
+func (c *DefaultLoggerCarrier) Log(
+	lvl LogLevel,
+	line string,
+	addr string,
+	args ...interface{},
+) {
+	logger, logLvl, logFmt := c.logger[lvl], c.logLvl, c.logFmt[lvl]
+
+	if logger == nil {
+		return
+	}
+
+	if logLvl > lvl {
+		return
+	}
+
+	logger.Output(
+		2,
+		fmt.Sprintf(
+			"%-4s %s %s",
+			lvl,
+			fmt.Sprintf(logFmt, addr),
+			fmt.Sprintf(line, args...),
+		),
+	)
+}
+
+type logger interface {
+	Output(calldepth int, s string) error
+}
+
+// LogLevel specifies the severity of a given log message
+type LogLevel int
+
+// Log levels
+const (
+	LogLevelDebug LogLevel = iota
+	LogLevelInfo
+	LogLevelWarning
+	LogLevelError
+	LogLevelMax = iota - 1 // convenience - match highest log level
+)
+
+// String returns the string form for a given LogLevel
+func (lvl LogLevel) String() string {
+	switch lvl {
+	case LogLevelInfo:
+		return "INF"
+	case LogLevelWarning:
+		return "WRN"
+	case LogLevelError:
+		return "ERR"
+	}
+	return "DBG"
+}

--- a/logger.go
+++ b/logger.go
@@ -12,7 +12,7 @@ type LoggerCarrierSetters interface {
 	SetLoggerLevel(lvl LogLevel)
 }
 
-type LoggerCarrierGetters interface {
+type loggerCarrierGetters interface {
 	GetLogLevel() LogLevel
 	GetLoggers() []logger
 	GetLogFormat(lvl LogLevel) string
@@ -20,11 +20,11 @@ type LoggerCarrierGetters interface {
 }
 
 type LoggerCarrier interface {
-	LoggerCarrierGetters
+	loggerCarrierGetters
 	LoggerCarrierSetters
 }
 
-type DefaultLoggerCarrier struct {
+type defaultLoggerCarrier struct {
 	LoggerCarrier
 
 	logger []logger
@@ -34,8 +34,8 @@ type DefaultLoggerCarrier struct {
 	logGuard sync.RWMutex
 }
 
-func NewDefaultLoggerCarrier() LoggerCarrier {
-	carrier := &DefaultLoggerCarrier{
+func newDefaultLoggerCarrier() LoggerCarrier {
+	carrier := &defaultLoggerCarrier{
 		logger: make([]logger, int(LogLevelMax+1)),
 		logLvl: LogLevelInfo,
 		logFmt: make([]string, LogLevelMax+1),
@@ -56,7 +56,7 @@ func NewDefaultLoggerCarrier() LoggerCarrier {
 //
 //    Output(calldepth int, s string)
 //
-func (c *DefaultLoggerCarrier) SetLogger(l logger, lvl LogLevel, format string) {
+func (c *defaultLoggerCarrier) SetLogger(l logger, lvl LogLevel, format string) {
 	c.logGuard.Lock()
 	defer c.logGuard.Unlock()
 
@@ -70,7 +70,7 @@ func (c *DefaultLoggerCarrier) SetLogger(l logger, lvl LogLevel, format string) 
 	c.logLvl = lvl
 }
 
-func (c *DefaultLoggerCarrier) SetLoggerForLevel(l logger, lvl LogLevel, format string) {
+func (c *defaultLoggerCarrier) SetLoggerForLevel(l logger, lvl LogLevel, format string) {
 	c.logGuard.Lock()
 	defer c.logGuard.Unlock()
 
@@ -81,35 +81,35 @@ func (c *DefaultLoggerCarrier) SetLoggerForLevel(l logger, lvl LogLevel, format 
 	c.logFmt[lvl] = format
 }
 
-func (c *DefaultLoggerCarrier) SetLoggerLevel(lvl LogLevel) {
+func (c *defaultLoggerCarrier) SetLoggerLevel(lvl LogLevel) {
 	c.logGuard.Lock()
 	defer c.logGuard.Unlock()
 
 	c.logLvl = lvl
 }
 
-func (c *DefaultLoggerCarrier) GetLoggers() []logger {
+func (c *defaultLoggerCarrier) GetLoggers() []logger {
 	c.logGuard.RLock()
 	defer c.logGuard.RUnlock()
 
 	return c.logger
 }
 
-func (c *DefaultLoggerCarrier) GetLogLevel() LogLevel {
+func (c *defaultLoggerCarrier) GetLogLevel() LogLevel {
 	c.logGuard.RLock()
 	defer c.logGuard.RUnlock()
 
 	return c.logLvl
 }
 
-func (c *DefaultLoggerCarrier) GetLogFormat(lvl LogLevel) string {
+func (c *defaultLoggerCarrier) GetLogFormat(lvl LogLevel) string {
 	c.logGuard.RLock()
 	defer c.logGuard.RUnlock()
 
 	return c.logFmt[lvl]
 }
 
-func (c *DefaultLoggerCarrier) Log(
+func (c *defaultLoggerCarrier) Log(
 	lvl LogLevel,
 	msg string,
 ) {

--- a/producer.go
+++ b/producer.go
@@ -7,9 +7,15 @@ import (
 	"time"
 )
 
-// Publisher describes the interface that should be implemented for a message
-// publisher.
-type Publisher interface {
+// Producer defines the public interface a producer should implement
+type Producer interface {
+	connEventsHandler
+	fmt.Stringer
+
+	SetLogger(l logger, lvl LogLevel)
+	SetLoggerLevel(lvl LogLevel)
+	SetLoggerForLevel(l logger, lvl LogLevel)
+
 	PublishAsync(
 		topic string,
 		body []byte,
@@ -32,17 +38,6 @@ type Publisher interface {
 		doneChan chan *ProducerTransaction,
 		args ...interface{},
 	) error
-}
-
-// Producer defines the public interface a producer should implement
-type Producer interface {
-	ConnEventsHandler
-	Publisher
-	fmt.Stringer
-
-	SetLogger(l logger, lvl LogLevel)
-	SetLoggerLevel(lvl LogLevel)
-	SetLoggerForLevel(l logger, lvl LogLevel)
 
 	Ping() error
 	Stop()
@@ -113,7 +108,7 @@ func NewProducer(addr string, config *Config) (Producer, error) {
 		addr:   addr,
 		config: *config,
 
-		loggerCarrier: NewDefaultLoggerCarrier(),
+		loggerCarrier: newDefaultLoggerCarrier(),
 
 		transactionChan: make(chan *ProducerTransaction),
 		exitChan:        make(chan int),

--- a/producer.go
+++ b/producer.go
@@ -2,37 +2,77 @@ package nsq
 
 import (
 	"fmt"
-	"log"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
 )
 
-type producerConn interface {
-	String() string
-	SetLogger(logger, LogLevel, string)
-	SetLoggerLevel(LogLevel)
-	SetLoggerForLevel(logger, LogLevel, string)
-	Connect() (*IdentifyResponse, error)
-	Close() error
-	WriteCommand(*Command) error
+// ConnEventsHandler describes the interface that should be implemented
+// for handling events that the a Conn might fire
+type ConnEventsHandler interface {
+	onConnResponse(c Conn, data []byte)
+	onConnError(c Conn, data []byte)
+	onConnHeartbeat(c Conn)
+	onConnIOError(c Conn, err error)
+	onConnClose(c Conn)
 }
 
-// Producer is a high-level type to publish to NSQ.
+// Publisher describes the interface that should be implemented for a message
+// publisher.
+type Publisher interface {
+	PublishAsync(
+		topic string,
+		body []byte,
+		doneChan chan *ProducerTransaction,
+		args ...interface{},
+	) error
+	MultiPublishAsync(
+		topic string,
+		body [][]byte,
+		doneChan chan *ProducerTransaction,
+		args ...interface{},
+	) error
+	Publish(topic string, body []byte) error
+	MultiPublish(topic string, body [][]byte) error
+	DeferredPublish(topic string, delay time.Duration, body []byte) error
+	DeferredPublishAsync(
+		topic string,
+		delay time.Duration,
+		body []byte,
+		doneChan chan *ProducerTransaction,
+		args ...interface{},
+	) error
+}
+
+// Producer defines the public interface a producer should implement
+type Producer interface {
+	ConnEventsHandler
+	Publisher
+	fmt.Stringer
+
+	Ping() error
+	Stop()
+
+	router()
+	getState() int32
+	setConn(c Conn)
+	setCloseChan(ch chan int)
+
+	SetLogger(l logger, lvl LogLevel)
+}
+
+// nsqProducer is a high-level type to publish to NSQ.
 //
-// A Producer instance is 1:1 with a destination `nsqd`
+// A nsqProducer instance is 1:1 with a destination `nsqd`
 // and will lazily connect to that instance (and re-connect)
 // when Publish commands are executed.
-type Producer struct {
+type nsqProducer struct {
 	id     int64
 	addr   string
-	conn   producerConn
+	conn   Conn
 	config Config
 
-	logger   []logger
-	logLvl   LogLevel
-	logGuard sync.RWMutex
+	loggerCarrier LoggerCarrier
 
 	responseChan chan []byte
 	errorChan    chan []byte
@@ -69,20 +109,19 @@ func (t *ProducerTransaction) finish() {
 //
 // The only valid way to create a Config is via NewConfig, using a struct literal will panic.
 // After Config is passed into NewProducer the values are no longer mutable (they are copied).
-func NewProducer(addr string, config *Config) (*Producer, error) {
+func NewProducer(addr string, config *Config) (Producer, error) {
 	err := config.Validate()
 	if err != nil {
 		return nil, err
 	}
 
-	p := &Producer{
+	p := &nsqProducer{
 		id: atomic.AddInt64(&instCount, 1),
 
 		addr:   addr,
 		config: *config,
 
-		logger: make([]logger, int(LogLevelMax+1)),
-		logLvl: LogLevelInfo,
+		loggerCarrier: NewDefaultLoggerCarrier(),
 
 		transactionChan: make(chan *ProducerTransaction),
 		exitChan:        make(chan int),
@@ -90,12 +129,19 @@ func NewProducer(addr string, config *Config) (*Producer, error) {
 		errorChan:       make(chan []byte),
 	}
 
-	// Set default logger for all log levels
-	l := log.New(os.Stderr, "", log.Flags())
-	for index, _ := range p.logger {
-		p.logger[index] = l
-	}
 	return p, nil
+}
+
+func (p *nsqProducer) getState() int32 {
+	return p.state
+}
+
+func (p *nsqProducer) setConn(conn Conn) {
+	p.conn = conn
+}
+
+func (p *nsqProducer) setCloseChan(ch chan int) {
+	p.closeChan = ch
 }
 
 // Ping causes the Producer to connect to it's configured nsqd (if not already
@@ -104,15 +150,15 @@ func NewProducer(addr string, config *Config) (*Producer, error) {
 // This method can be used to verify that a newly-created Producer instance is
 // configured correctly, rather than relying on the lazy "connect on Publish"
 // behavior of a Producer.
-func (w *Producer) Ping() error {
-	if atomic.LoadInt32(&w.state) != StateConnected {
-		err := w.connect()
+func (p *nsqProducer) Ping() error {
+	if atomic.LoadInt32(&p.state) != StateConnected {
+		err := p.connect()
 		if err != nil {
 			return err
 		}
 	}
 
-	return w.conn.WriteCommand(Nop())
+	return p.conn.WriteCommand(Nop())
 }
 
 // SetLogger assigns the logger to use as well as a level
@@ -122,65 +168,39 @@ func (w *Producer) Ping() error {
 //
 //    Output(calldepth int, s string)
 //
-func (w *Producer) SetLogger(l logger, lvl LogLevel) {
-	w.logGuard.Lock()
-	defer w.logGuard.Unlock()
-
-	for level := range w.logger {
-		w.logger[level] = l
-	}
-	w.logLvl = lvl
+func (p *nsqProducer) SetLogger(l logger, lvl LogLevel) {
+	p.loggerCarrier.SetLogger(l, lvl, "")
 }
 
 // SetLoggerForLevel assigns the same logger for specified `level`.
-func (w *Producer) SetLoggerForLevel(l logger, lvl LogLevel) {
-	w.logGuard.Lock()
-	defer w.logGuard.Unlock()
-
-	w.logger[lvl] = l
+func (p *nsqProducer) SetLoggerForLevel(l logger, lvl LogLevel) {
+	p.loggerCarrier.SetLoggerForLevel(l, lvl, "(%s)")
 }
 
 // SetLoggerLevel sets the package logging level.
-func (w *Producer) SetLoggerLevel(lvl LogLevel) {
-	w.logGuard.Lock()
-	defer w.logGuard.Unlock()
-
-	w.logLvl = lvl
-}
-
-func (w *Producer) getLogger(lvl LogLevel) (logger, LogLevel) {
-	w.logGuard.RLock()
-	defer w.logGuard.RUnlock()
-
-	return w.logger[lvl], w.logLvl
-}
-
-func (w *Producer) getLogLevel() LogLevel {
-	w.logGuard.RLock()
-	defer w.logGuard.RUnlock()
-
-	return w.logLvl
+func (p *nsqProducer) SetLoggerLevel(lvl LogLevel) {
+	p.loggerCarrier.SetLoggerLevel(lvl)
 }
 
 // String returns the address of the Producer
-func (w *Producer) String() string {
-	return w.addr
+func (p *nsqProducer) String() string {
+	return p.addr
 }
 
 // Stop initiates a graceful stop of the Producer (permanent)
 //
 // NOTE: this blocks until completion
-func (w *Producer) Stop() {
-	w.guard.Lock()
-	if !atomic.CompareAndSwapInt32(&w.stopFlag, 0, 1) {
-		w.guard.Unlock()
+func (p *nsqProducer) Stop() {
+	p.guard.Lock()
+	if !atomic.CompareAndSwapInt32(&p.stopFlag, 0, 1) {
+		p.guard.Unlock()
 		return
 	}
-	w.log(LogLevelInfo, "stopping")
-	close(w.exitChan)
-	w.close()
-	w.guard.Unlock()
-	w.wg.Wait()
+	p.log(LogLevelInfo, "stopping")
+	close(p.exitChan)
+	p.close()
+	p.guard.Unlock()
+	p.wg.Wait()
 }
 
 // PublishAsync publishes a message body to the specified topic
@@ -190,9 +210,9 @@ func (w *Producer) Stop() {
 // the supplied `doneChan` (if specified)
 // will receive a `ProducerTransaction` instance with the supplied variadic arguments
 // and the response error if present
-func (w *Producer) PublishAsync(topic string, body []byte, doneChan chan *ProducerTransaction,
+func (p *nsqProducer) PublishAsync(topic string, body []byte, doneChan chan *ProducerTransaction,
 	args ...interface{}) error {
-	return w.sendCommandAsync(Publish(topic, body), doneChan, args)
+	return p.sendCommandAsync(Publish(topic, body), doneChan, args)
 }
 
 // MultiPublishAsync publishes a slice of message bodies to the specified topic
@@ -202,36 +222,36 @@ func (w *Producer) PublishAsync(topic string, body []byte, doneChan chan *Produc
 // the supplied `doneChan` (if specified)
 // will receive a `ProducerTransaction` instance with the supplied variadic arguments
 // and the response error if present
-func (w *Producer) MultiPublishAsync(topic string, body [][]byte, doneChan chan *ProducerTransaction,
+func (p *nsqProducer) MultiPublishAsync(topic string, body [][]byte, doneChan chan *ProducerTransaction,
 	args ...interface{}) error {
 	cmd, err := MultiPublish(topic, body)
 	if err != nil {
 		return err
 	}
-	return w.sendCommandAsync(cmd, doneChan, args)
+	return p.sendCommandAsync(cmd, doneChan, args)
 }
 
 // Publish synchronously publishes a message body to the specified topic, returning
 // an error if publish failed
-func (w *Producer) Publish(topic string, body []byte) error {
-	return w.sendCommand(Publish(topic, body))
+func (p *nsqProducer) Publish(topic string, body []byte) error {
+	return p.sendCommand(Publish(topic, body))
 }
 
 // MultiPublish synchronously publishes a slice of message bodies to the specified topic, returning
 // an error if publish failed
-func (w *Producer) MultiPublish(topic string, body [][]byte) error {
+func (p *nsqProducer) MultiPublish(topic string, body [][]byte) error {
 	cmd, err := MultiPublish(topic, body)
 	if err != nil {
 		return err
 	}
-	return w.sendCommand(cmd)
+	return p.sendCommand(cmd)
 }
 
 // DeferredPublish synchronously publishes a message body to the specified topic
 // where the message will queue at the channel level until the timeout expires, returning
 // an error if publish failed
-func (w *Producer) DeferredPublish(topic string, delay time.Duration, body []byte) error {
-	return w.sendCommand(DeferredPublish(topic, delay, body))
+func (p *nsqProducer) DeferredPublish(topic string, delay time.Duration, body []byte) error {
+	return p.sendCommand(DeferredPublish(topic, delay, body))
 }
 
 // DeferredPublishAsync publishes a message body to the specified topic
@@ -242,14 +262,14 @@ func (w *Producer) DeferredPublish(topic string, delay time.Duration, body []byt
 // the supplied `doneChan` (if specified)
 // will receive a `ProducerTransaction` instance with the supplied variadic arguments
 // and the response error if present
-func (w *Producer) DeferredPublishAsync(topic string, delay time.Duration, body []byte,
+func (p *nsqProducer) DeferredPublishAsync(topic string, delay time.Duration, body []byte,
 	doneChan chan *ProducerTransaction, args ...interface{}) error {
-	return w.sendCommandAsync(DeferredPublish(topic, delay, body), doneChan, args)
+	return p.sendCommandAsync(DeferredPublish(topic, delay, body), doneChan, args)
 }
 
-func (w *Producer) sendCommand(cmd *Command) error {
+func (p *nsqProducer) sendCommand(cmd *Command) error {
 	doneChan := make(chan *ProducerTransaction)
-	err := w.sendCommandAsync(cmd, doneChan, nil)
+	err := p.sendCommandAsync(cmd, doneChan, nil)
 	if err != nil {
 		close(doneChan)
 		return err
@@ -258,15 +278,15 @@ func (w *Producer) sendCommand(cmd *Command) error {
 	return t.Error
 }
 
-func (w *Producer) sendCommandAsync(cmd *Command, doneChan chan *ProducerTransaction,
+func (p *nsqProducer) sendCommandAsync(cmd *Command, doneChan chan *ProducerTransaction,
 	args []interface{}) error {
 	// keep track of how many outstanding producers we're dealing with
 	// in order to later ensure that we clean them all up...
-	atomic.AddInt32(&w.concurrentProducers, 1)
-	defer atomic.AddInt32(&w.concurrentProducers, -1)
+	atomic.AddInt32(&p.concurrentProducers, 1)
+	defer atomic.AddInt32(&p.concurrentProducers, -1)
 
-	if atomic.LoadInt32(&w.state) != StateConnected {
-		err := w.connect()
+	if atomic.LoadInt32(&p.state) != StateConnected {
+		err := p.connect()
 		if err != nil {
 			return err
 		}
@@ -279,23 +299,23 @@ func (w *Producer) sendCommandAsync(cmd *Command, doneChan chan *ProducerTransac
 	}
 
 	select {
-	case w.transactionChan <- t:
-	case <-w.exitChan:
+	case p.transactionChan <- t:
+	case <-p.exitChan:
 		return ErrStopped
 	}
 
 	return nil
 }
 
-func (w *Producer) connect() error {
-	w.guard.Lock()
-	defer w.guard.Unlock()
+func (p *nsqProducer) connect() error {
+	p.guard.Lock()
+	defer p.guard.Unlock()
 
-	if atomic.LoadInt32(&w.stopFlag) == 1 {
+	if atomic.LoadInt32(&p.stopFlag) == 1 {
 		return ErrStopped
 	}
 
-	switch state := atomic.LoadInt32(&w.state); state {
+	switch state := atomic.LoadInt32(&p.state); state {
 	case StateInit:
 	case StateConnected:
 		return nil
@@ -303,97 +323,97 @@ func (w *Producer) connect() error {
 		return ErrNotConnected
 	}
 
-	w.log(LogLevelInfo, "(%s) connecting to nsqd", w.addr)
+	p.log(LogLevelInfo, "(%s) connecting to nsqd", p.addr)
 
-	w.conn = NewConn(w.addr, &w.config, &producerConnDelegate{w})
-	w.conn.SetLoggerLevel(w.getLogLevel())
-	format := fmt.Sprintf("%3d (%%s)", w.id)
-	for index := range w.logger {
-		w.conn.SetLoggerForLevel(w.logger[index], LogLevel(index), format)
+	p.conn = NewConn(p.addr, &p.config, &producerConnDelegate{p})
+	p.conn.SetLoggerLevel(p.loggerCarrier.GetLogLevel())
+	format := fmt.Sprintf("%3d (%%s)", p.id)
+	for index, l := range p.loggerCarrier.GetLoggers() {
+		p.conn.SetLoggerForLevel(l, LogLevel(index), format)
 	}
 
-	_, err := w.conn.Connect()
+	_, err := p.conn.Connect()
 	if err != nil {
-		w.conn.Close()
-		w.log(LogLevelError, "(%s) error connecting to nsqd - %s", w.addr, err)
+		p.conn.Close()
+		p.log(LogLevelError, "(%s) error connecting to nsqd - %s", p.addr, err)
 		return err
 	}
-	atomic.StoreInt32(&w.state, StateConnected)
-	w.closeChan = make(chan int)
-	w.wg.Add(1)
-	go w.router()
+	atomic.StoreInt32(&p.state, StateConnected)
+	p.closeChan = make(chan int)
+	p.wg.Add(1)
+	go p.router()
 
 	return nil
 }
 
-func (w *Producer) close() {
-	if !atomic.CompareAndSwapInt32(&w.state, StateConnected, StateDisconnected) {
+func (p *nsqProducer) close() {
+	if !atomic.CompareAndSwapInt32(&p.state, StateConnected, StateDisconnected) {
 		return
 	}
-	w.conn.Close()
+	p.conn.Close()
 	go func() {
 		// we need to handle this in a goroutine so we don't
 		// block the caller from making progress
-		w.wg.Wait()
-		atomic.StoreInt32(&w.state, StateInit)
+		p.wg.Wait()
+		atomic.StoreInt32(&p.state, StateInit)
 	}()
 }
 
-func (w *Producer) router() {
+func (p *nsqProducer) router() {
 	for {
 		select {
-		case t := <-w.transactionChan:
-			w.transactions = append(w.transactions, t)
-			err := w.conn.WriteCommand(t.cmd)
+		case t := <-p.transactionChan:
+			p.transactions = append(p.transactions, t)
+			err := p.conn.WriteCommand(t.cmd)
 			if err != nil {
-				w.log(LogLevelError, "(%s) sending command - %s", w.conn.String(), err)
-				w.close()
+				p.log(LogLevelError, "(%s) sending command - %s", p.conn.String(), err)
+				p.close()
 			}
-		case data := <-w.responseChan:
-			w.popTransaction(FrameTypeResponse, data)
-		case data := <-w.errorChan:
-			w.popTransaction(FrameTypeError, data)
-		case <-w.closeChan:
+		case data := <-p.responseChan:
+			p.popTransaction(FrameTypeResponse, data)
+		case data := <-p.errorChan:
+			p.popTransaction(FrameTypeError, data)
+		case <-p.closeChan:
 			goto exit
-		case <-w.exitChan:
+		case <-p.exitChan:
 			goto exit
 		}
 	}
 
 exit:
-	w.transactionCleanup()
-	w.wg.Done()
-	w.log(LogLevelInfo, "exiting router")
+	p.transactionCleanup()
+	p.wg.Done()
+	p.log(LogLevelInfo, "exiting router")
 }
 
-func (w *Producer) popTransaction(frameType int32, data []byte) {
-	t := w.transactions[0]
-	w.transactions = w.transactions[1:]
+func (p *nsqProducer) popTransaction(frameType int32, data []byte) {
+	t := p.transactions[0]
+	p.transactions = p.transactions[1:]
 	if frameType == FrameTypeError {
 		t.Error = ErrProtocol{string(data)}
 	}
 	t.finish()
 }
 
-func (w *Producer) transactionCleanup() {
+func (p *nsqProducer) transactionCleanup() {
 	// clean up transactions we can easily account for
-	for _, t := range w.transactions {
+	for _, t := range p.transactions {
 		t.Error = ErrNotConnected
 		t.finish()
 	}
-	w.transactions = w.transactions[:0]
+	p.transactions = p.transactions[:0]
 
 	// spin and free up any writes that might have raced
 	// with the cleanup process (blocked on writing
 	// to transactionChan)
 	for {
 		select {
-		case t := <-w.transactionChan:
+		case t := <-p.transactionChan:
 			t.Error = ErrNotConnected
 			t.finish()
 		default:
 			// keep spinning until there are 0 concurrent producers
-			if atomic.LoadInt32(&w.concurrentProducers) == 0 {
+			if atomic.LoadInt32(&p.concurrentProducers) == 0 {
 				return
 			}
 			// give the runtime a chance to schedule other racing goroutines
@@ -402,26 +422,16 @@ func (w *Producer) transactionCleanup() {
 	}
 }
 
-func (w *Producer) log(lvl LogLevel, line string, args ...interface{}) {
-	logger, logLvl := w.getLogger(lvl)
-
-	if logger == nil {
-		return
-	}
-
-	if logLvl > lvl {
-		return
-	}
-
-	logger.Output(2, fmt.Sprintf("%-4s %3d %s", lvl, w.id, fmt.Sprintf(line, args...)))
+func (p *nsqProducer) log(lvl LogLevel, line string, args ...interface{}) {
+	p.loggerCarrier.Log(lvl, line, p.String(), args...)
 }
 
-func (w *Producer) onConnResponse(c *Conn, data []byte) { w.responseChan <- data }
-func (w *Producer) onConnError(c *Conn, data []byte)    { w.errorChan <- data }
-func (w *Producer) onConnHeartbeat(c *Conn)             {}
-func (w *Producer) onConnIOError(c *Conn, err error)    { w.close() }
-func (w *Producer) onConnClose(c *Conn) {
-	w.guard.Lock()
-	defer w.guard.Unlock()
-	close(w.closeChan)
+func (p *nsqProducer) onConnResponse(c Conn, data []byte) { p.responseChan <- data }
+func (p *nsqProducer) onConnError(c Conn, data []byte)    { p.errorChan <- data }
+func (p *nsqProducer) onConnHeartbeat(c Conn)             {}
+func (p *nsqProducer) onConnIOError(c Conn, err error)    { p.close() }
+func (p *nsqProducer) onConnClose(c Conn) {
+	p.guard.Lock()
+	defer p.guard.Unlock()
+	close(p.closeChan)
 }

--- a/producer_test.go
+++ b/producer_test.go
@@ -17,7 +17,7 @@ import (
 
 type ConsumerHandler struct {
 	t              *testing.T
-	q              *Consumer
+	q              Consumer
 	messagesGood   int
 	messagesFailed int
 }
@@ -272,7 +272,7 @@ func readMessages(topicName string, t *testing.T, msgCount int) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	<-q.StopChan
+	<-q.GetStopChan()
 
 	if h.messagesGood != msgCount {
 		t.Fatalf("end of test. should have handled a diff number of messages %d != %d", h.messagesGood, msgCount)

--- a/producer_test.go
+++ b/producer_test.go
@@ -330,12 +330,12 @@ func (m *mockProducerConn) Flush() error {
 	return nil
 }
 
-func (m *mockProducerConn) GetInflightMessageCount() *int64 {
+func (m *mockProducerConn) getInflightMessageCount() *int64 {
 	count := int64(0)
 	return &count
 }
 
-func (m *mockProducerConn) GetUnderlyingTCPConn() *net.TCPConn {
+func (m *mockProducerConn) getUnderlyingTCPConn() *net.TCPConn {
 	return nil
 }
 


### PR DESCRIPTION
Hi,

I’ve been using NSQ in production for more than 3 years now and I sincerely want to thank you guys for the great work you’ve been doing. 

This PR aims to expose newly created interfaces for `Conn`, `Consumer` and `Producer`, with the goal of making testing simpler. Please note that this PR does not break the current API in any way and that all the changes have been made with respect to the documentation.

I know that this point was already discussed in #146 and I saw that PRs were welcome. So if it’s still the case and you think this kind of modification could be in respect with the roadmap, I would be more than glad to fix everything that needs to be in this PR. Otherwise, I can just close if. Just let me know if all this does not make any sense to you. 

Please find below the definition of the main interfaces. More private ones are in the code. Obviously all the namings can be discussed. This was not the purpose of my contribution. 

```go
type Conn interface {
    fmt.Stringer

    LoggerCarrierSetters

    Connect() (*IdentifyResponse, error)
    RemoteAddr() net.Addr
    Read(p []byte) (int, error)
    Write(p []byte) (int, error)
    WriteCommand(cmd *Command) error
    RDY() int64
    SetRDY(rdy int64)
    MaxRDY() int64
    LastRDY() int64
    LastRdyTime() time.Time
    LastMessageTime() time.Time
    Flush() error
    Close() error
    IsClosing() bool
}

type Producer interface {
    fmt.Stringer
     // Please note that those 3 prototypes could potentially be removed from this interface 
    // and migrated somewhere else, see below
    SetLogger(l logger, lvl LogLevel)
    SetLoggerLevel(lvl LogLevel)
    SetLoggerForLevel(l logger, lvl LogLevel)

    PublishAsync(
        topic string,
        body []byte,
        doneChan chan *ProducerTransaction,
        args ...interface{},
    ) error
    MultiPublishAsync(
        topic string,
        body [][]byte,
        doneChan chan *ProducerTransaction,
        args ...interface{},
    ) error
    Publish(topic string, body []byte) error
    MultiPublish(topic string, body [][]byte) error
    DeferredPublish(topic string, delay time.Duration, body []byte) error
    DeferredPublishAsync(
        topic string,
        delay time.Duration,
        body []byte,
        doneChan chan *ProducerTransaction,
        args ...interface{},
    ) error

    Ping() error
    Stop()
}

type Consumer interface { 
    // Please note that those 3 prototypes could potentially be removed from this interface 
    // and migrated somewhere else, see below
    SetLogger(l logger, lvl LogLevel)
    SetLoggerLevel(lvl LogLevel)
    SetLoggerForLevel(l logger, lvl LogLevel)

    ConnectToNSQLookupd(addr string) error
    ConnectToNSQLookupds(addresses []string) error
    ConnectToNSQDs(addresses []string) error
    ConnectToNSQD(addr string) error
    DisconnectFromNSQD(addr string) error
    DisconnectFromNSQLookupd(addr string) error

    AddHandler(handler Handler)
    AddConcurrentHandlers(handler Handler, concurrency int)

    Stats() *ConsumerStats
    SetBehaviorDelegate(cb interface{})

    IsStarved() bool
    ChangeMaxInFlight(maxInFlight int)

    Stop()
    GetStopChan() chan int
}
```

I also did my best to factorize code as much as possible in the logging part. Some code was duplicated across both the `consumer.go`, `producer.go` and `conn.go`, so I thought it might be interesting to gather everything into its own interface, and a default implementation. 
 If this is something you might be interested in, the limiting part of this side is that the public API of `Conn` exposes a different prototype for both `SetLogger` and `SetLoggerForLevel`, compared to the ones exposed by `Consumer` and `Producer`.

Please note that this could be refactorized pretty easily, breaking the API but without any functional changes (e.g. using a default value for `format`).  Thank you for taking the time to read and consider this PR
