### PR TITLE
*: add AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,15 @@
+# For a complete listing, see https://github.com/nsqio/go-nsq/graphs/contributors
+
+# Original Authors
+
+Matt Reiferson <mreiferson@gmail.com>
+Jehiah Czebotar <jehiah@gmail.com>
+
+# Maintainers
+
+Pierce Lopez <ploxiln@gmail.com>
+
+# Disclaimer
+
+Matt Reiferson's contributions to this project are being made solely in a personal capacity
+and does not convey any rights to any intellectual property of any third parties.


### PR DESCRIPTION
Going to update `nsq` and `pynsq` repos to follow this format as well, instead of copying around the README blob.