### PR TITLE
ProducerPool - easier remote publishing

### DIFF
--- a/producer_pool.go
+++ b/producer_pool.go
@@ -1,0 +1,51 @@
+package nsq
+
+import (
+	"sync/atomic"
+)
+
+// ProducerPool provides a round robin publish to a pool of producers with built in retry
+//
+// This includes a transparent retry when a publish fails, and a backoff when
+// encountering errors
+type ProducerPool struct {
+	Producers   []*Producer
+	MaxAttempts int
+	next        uint32
+}
+
+func NewProducerPool(addrs []string, cfg *Config) (*ProducerPool, error) {
+	p := &ProducerPool{
+		Producers: make([]*Producer, len(addrs)),
+	}
+	for i, a := range addrs {
+		np, err := NewProducer(a, cfg)
+		if err != nil {
+			return nil, err
+		}
+		p.Producers[i] = np
+	}
+	return p, nil
+}
+
+// Publish does a round-robin publish, if a publish fails it will retry up to 3 attempts
+// and will publish sequentially to the next sequential items in the pool
+func (p *ProducerPool) Publish(topic string, body []byte) error {
+	n := atomic.AddUint32(&p.next, 1)
+	l := len(p.Producers)
+	var err error
+
+	for attempt := 0; (attempt <= p.MaxAttempts || p.MaxAttempts <= 0) && attempt < l; attempt++ {
+		producer := p.Producers[(int(n)+attempt-1)%l]
+		err = producer.Publish(topic, body)
+		if err == nil {
+			return nil
+		}
+		producer.log(LogLevelInfo, "(%s) publish error - %s", producer.conn.String(), err)
+	}
+	return err
+}
+
+func (p ProducerPool) PublishAsync(topic string, body []byte, doneChan chan *ProducerTransaction, args ...interface{}) error {
+	panic("not implemented")
+}


### PR DESCRIPTION
go-nsq does not provide good primitives to handle failures when publishing to a nsq instances; Handling publish errors is left as an exercise for the developer when that logic is important for reliable message creation. Common guidance has been to prefer publishing to a colocated nsqd instance, but that configuration is less desirable in many cloud environments.

I'm proposing we add a `ProducerPool` which provides a Publish interface that can be configured with multiple nsqd instances and which will retry publishing to another instance on error. This will provide a simple way for applications publishing messages to handle write failures in a fault tolerant way. 

Based on outcome of nsqio/nsq#1300 this producer may also lazily organize nsqd instances into groupings of node local, zone local, region local or global and provide prioritization base on topology.

Functionally this is similar to the reliable publishing in `nsq_to_nsq` where publish happens in a round robin, or host pool to a pool of nsqd instances (but without the same backpressure).

cc: nsqio/nsq#1254 which tracks facilitating use of nsq in a cloud environment.