### PR TITLE
Set topology region+zone and send in IDENTIFY msg

### DIFF
--- a/config.go
+++ b/config.go
@@ -140,6 +140,10 @@ type Config struct {
 	Hostname  string `opt:"hostname"`
 	UserAgent string `opt:"user_agent"`
 
+	// Topology hints allow nsqd to prefer same zone and same region consumers
+	TopologyRegion string `opt:"topology_region"`
+	TopologyZone   string `opt:"topology_zone"`
+
 	// Duration of time between heartbeats. This must be less than ReadTimeout
 	HeartbeatInterval time.Duration `opt:"heartbeat_interval" default:"30s"`
 	// Integer percentage to sample the channel (requires nsqd 0.2.25+)

--- a/conn.go
+++ b/conn.go
@@ -345,6 +345,8 @@ func (c *Conn) identify() (*IdentifyResponse, error) {
 		ci["output_buffer_timeout"] = int64(c.config.OutputBufferTimeout / time.Millisecond)
 	}
 	ci["msg_timeout"] = int64(c.config.MsgTimeout / time.Millisecond)
+	ci["topology_region"] = c.config.TopologyRegion
+	ci["topology_zone"] = c.config.TopologyZone
 	cmd, err := Identify(ci)
 	if err != nil {
 		return nil, ErrIdentify{err.Error()}


### PR DESCRIPTION
This supports nsqio/nsq#1300 by providing a way to send topology information to nsqd