### PR TITLE
Use AuthSecret as Bearer token for lookupd queries

### DIFF
--- a/api_request.go
+++ b/api_request.go
@@ -3,7 +3,6 @@ package nsq
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -46,11 +45,14 @@ type wrappedResp struct {
 }
 
 // stores the result in the value pointed to by ret(must be a pointer)
-func apiRequestNegotiateV1(method string, endpoint string, body io.Reader, ret interface{}) error {
+func apiRequestNegotiateV1(method string, endpoint string, headers http.Header, ret interface{}) error {
 	httpclient := &http.Client{Transport: newDeadlineTransport(2 * time.Second)}
-	req, err := http.NewRequest(method, endpoint, body)
+	req, err := http.NewRequest(method, endpoint, nil)
 	if err != nil {
 		return err
+	}
+	for k, v := range headers {
+		req.Header[k] = v
 	}
 
 	req.Header.Add("Accept", "application/vnd.nsq; version=1.0")

--- a/config.go
+++ b/config.go
@@ -176,8 +176,10 @@ type Config struct {
 	// The server-side message timeout for messages delivered to this client
 	MsgTimeout time.Duration `opt:"msg_timeout" min:"0"`
 
-	// secret for nsqd authentication (requires nsqd 0.2.29+)
+	// Secret for nsqd authentication (requires nsqd 0.2.29+)
 	AuthSecret string `opt:"auth_secret"`
+	// Use AuthSecret as 'Authorization: Bearer {AuthSecret}' on lookupd queries
+	LookupdAuthorization bool `opt:"skip_lookupd_authorization" default:"true"`
 }
 
 // NewConfig returns a new default nsq configuration.

--- a/consumer.go
+++ b/consumer.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -492,7 +493,11 @@ retry:
 	r.log(LogLevelInfo, "querying nsqlookupd %s", endpoint)
 
 	var data lookupResp
-	err := apiRequestNegotiateV1("GET", endpoint, nil, &data)
+	headers := make(http.Header)
+	if r.config.AuthSecret != "" && r.config.LookupdAuthorization {
+		headers.Set("Authorization", fmt.Sprintf("Bearer %s", r.config.AuthSecret))
+	}
+	err := apiRequestNegotiateV1("GET", endpoint, headers, &data)
 	if err != nil {
 		r.log(LogLevelError, "error querying nsqlookupd (%s) - %s", endpoint, err)
 		retries++


### PR DESCRIPTION
The [`AUTH` protocol spec](https://nsq.io/clients/tcp_protocol_spec.html#auth)  and [nsqd AUTH details](https://nsq.io/components/nsqd.html#auth) don't give much guidance for how to use AUTH with a lookupd endpoint (except implying that [`nsqauthfilter`](https://github.com/jehiah/nsqauth-contrib#nsqauthfilter) is one approach).

Currently the only exposed capability to use a lookup endpoint that requires authorization is to bake authorization credentials into the URL used as a lookup endpoint. go-nsq then makes a GET request to that endpoint during discovery.

Security best practice is to move authorization details to a header and out of the URL i.e. a `Authorization: Bearer {Auth Secret}` header.

This issue is to introduce new behavior where an AuthSecret when set is used as a Bearer token on lookupd calls. That seems like a sane default

`SkipLookupdAuthorization` can be used to opt into the current behavior (AuthSecret not used on lookupd requests)

cc: @mreiferson @ploxiln  in case you have any thoughts on this approach. I think our AUTH docs could use a little help, i'll try to build some better documentation of that.
