### PR TITLE
Check nsqlookupd list emptiness on Consumer instantiation

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -374,6 +374,9 @@ func (r *Consumer) ConnectToNSQLookupd(addr string) error {
 //
 // A goroutine is spawned to handle continual polling.
 func (r *Consumer) ConnectToNSQLookupds(addresses []string) error {
+	if len(addresses) == 0 {
+		return errors.New("empty nsqlookupd servers list provided")
+	}
 	for _, addr := range addresses {
 		err := r.ConnectToNSQLookupd(addr)
 		if err != nil {


### PR DESCRIPTION
If empty nsqlookupd servers list is `ConnectToNSQLookupds` is provided, then Consumer instantiation does not fail, which is confusing. This PR makes it return an error for such case.