### PR TITLE
producer: improve code readability

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -295,11 +295,11 @@ func (w *Producer) connect() error {
 		return ErrStopped
 	}
 
-	switch state := atomic.LoadInt32(&w.state); state {
-	case StateInit:
-	case StateConnected:
+	state := atomic.LoadInt32(&w.state)
+	switch  {
+	case state == StateConnected:
 		return nil
-	default:
+	case state != StateInit:
 		return ErrNotConnected
 	}
 


### PR DESCRIPTION
Removing empty switch case makes the code more readable.
See https://github.com/nsqio/go-nsq/pull/310#discussion_r517885032