### PR TITLE
feat: reuse http client

### DIFF
--- a/api_request.go
+++ b/api_request.go
@@ -47,8 +47,7 @@ type wrappedResp struct {
 }
 
 // stores the result in the value pointed to by ret(must be a pointer)
-func apiRequestNegotiateV1(method string, endpoint string, headers http.Header, ret interface{}) error {
-	httpclient := &http.Client{Transport: newDeadlineTransport(2 * time.Second)}
+func apiRequestNegotiateV1(httpclient *http.Client, method string, endpoint string, headers http.Header, ret interface{}) error {
 	req, err := http.NewRequest(method, endpoint, nil)
 	if err != nil {
 		return err

--- a/config.go
+++ b/config.go
@@ -108,8 +108,10 @@ type Config struct {
 	//
 	// NOTE: when not using nsqlookupd, LookupdPollInterval represents the duration of time between
 	// reconnection attempts
-	LookupdPollInterval time.Duration `opt:"lookupd_poll_interval" min:"10ms" max:"5m" default:"60s"`
-	LookupdPollJitter   float64       `opt:"lookupd_poll_jitter" min:"0" max:"1" default:"0.3"`
+	LookupdPollInterval      time.Duration `opt:"lookupd_poll_interval" min:"10ms" max:"5m" default:"60s"`
+	LookupdPollJitter        float64       `opt:"lookupd_poll_jitter" min:"0" max:"1" default:"0.3"`
+	LookupdPollAliveDuration time.Duration `opt:"lookupd_pool_alive_duration" default:"60s"`
+	LookupdPollTimeout       time.Duration `opt:"lookupd_poll_timeout" default:"6s"`
 
 	// Maximum duration when REQueueing (for doubling of deferred requeue)
 	MaxRequeueDelay     time.Duration `opt:"max_requeue_delay" min:"0" max:"60m" default:"15m"`

--- a/consumer.go
+++ b/consumer.go
@@ -128,6 +128,7 @@ type Consumer struct {
 	lookupdRecheckChan chan int
 	lookupdHTTPAddrs   []string
 	lookupdQueryIndex  int
+	lookupdHttpClient  *http.Client
 
 	wg              sync.WaitGroup
 	runningHandlers int32
@@ -355,6 +356,21 @@ func (r *Consumer) ConnectToNSQLookupd(addr string) error {
 		}
 	}
 	r.lookupdHTTPAddrs = append(r.lookupdHTTPAddrs, parsedAddr)
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   r.config.LookupdPollTimeout,
+			KeepAlive: r.config.LookupdPollAliveDuration,
+			DualStack: true,
+		}).DialContext,
+		ResponseHeaderTimeout: r.config.LookupdPollTimeout,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+	}
+	r.lookupdHttpClient = &http.Client{
+		Transport: transport,
+		Timeout:   r.config.LookupdPollTimeout,
+	}
 	numLookupd := len(r.lookupdHTTPAddrs)
 	r.mtx.Unlock()
 
@@ -468,7 +484,7 @@ retry:
 	if r.config.AuthSecret != "" && r.config.LookupdAuthorization {
 		headers.Set("Authorization", fmt.Sprintf("Bearer %s", r.config.AuthSecret))
 	}
-	err := apiRequestNegotiateV1("GET", endpoint, headers, &data)
+	err := apiRequestNegotiateV1(r.lookupdHttpClient, "GET", endpoint, headers, &data)
 	if err != nil {
 		r.log(LogLevelError, "error querying nsqlookupd (%s) - %s", endpoint, err)
 		retries++


### PR DESCRIPTION
### Problem
After some wrong happend on my machine, i found there are many `TIME_WAIT` status. 
I have many nsqd topics and n consumers, consumer making http request which not using `Keep-Alive` causes this problem.
~~~
[xxx@xxx-inc.com server]$ netstat -an |grep 19991|awk '{print $6}'|sort|uniq -c
      2 ESTABLISHED
      1 LISTEN
   1401 TIME_WAIT
~~~

### Solution
1. using go http.Transport features(keepalives,timeouts,dualstack)
2. reuse http client
~~~
[xxx@xxx-inc.com server]$ netstat -an |grep 19991|awk '{print $6}'|sort|uniq -c
   1217 ESTABLISHED
      1 LISTEN
    305 TIME_WAIT
~~~

3. support setting lookupd http client
~~~
[xxx@xxx-inc.com server]$ netstat -an |grep 19991|awk '{print $6}'|sort|uniq -c
    131 ESTABLISHED
      1 LISTEN
    355 TIME_WAIT
~~~