### PR TITLE
producer: fix shutdown logs to be uniform with others

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -176,7 +176,7 @@ func (w *Producer) Stop() {
 		w.guard.Unlock()
 		return
 	}
-	w.log(LogLevelInfo, "stopping")
+	w.log(LogLevelInfo, "(%s) stopping", w.addr)
 	close(w.exitChan)
 	w.close()
 	w.guard.Unlock()
@@ -296,7 +296,7 @@ func (w *Producer) connect() error {
 	}
 
 	state := atomic.LoadInt32(&w.state)
-	switch  {
+	switch {
 	case state == StateConnected:
 		return nil
 	case state != StateInit:
@@ -363,7 +363,7 @@ func (w *Producer) router() {
 exit:
 	w.transactionCleanup()
 	w.wg.Done()
-	w.log(LogLevelInfo, "exiting router")
+	w.log(LogLevelInfo, "(%s) exiting router", w.conn.String())
 }
 
 func (w *Producer) popTransaction(frameType int32, data []byte) {


### PR DESCRIPTION
Almost all the producer logs are tagged with the NSQD daemon address (from where it's ID originates from)... except the 2 shutdown logs.

This is bothersome if a process creates multiple producers on multiple NSQD daemons as the IDs will overlap and the missing address will cause it to be hard to match up with the correct producer. It is also annoying when post-processing logs as the format needs to be special cased.

This PR fixes the 2 log invocations to add the NSQD address to them too. AFAIK both should be fine as these are only invoked after a successful connection, so the address should be set.

E.g.

Before:

```
INF    1 ([::]:4150) connecting to nsqd
INF    1 ([::]:4150) upgrading to TLS
INF    1 ([::]:4150) upgrading to Snappy
INF    1 stopping
INF    1 ([::]:4150) beginning close
INF    1 exiting router
INF    1 ([::]:4150) readLoop exiting
INF    1 ([::]:4150) breaking out of writeLoop
INF    1 ([::]:4150) writeLoop exiting
```

After:

```
INF    1 ([::]:4150) connecting to nsqd
INF    1 ([::]:4150) upgrading to TLS
INF    1 ([::]:4150) upgrading to Snappy
INF    1 ([::]:4150) stopping
INF    1 ([::]:4150) beginning close
INF    1 ([::]:4150) exiting router
INF    1 ([::]:4150) readLoop exiting
INF    1 ([::]:4150) breaking out of writeLoop
INF    1 ([::]:4150) writeLoop exiting
```