### PR TITLE
producer: handle case of no transactions in popTransaction()

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -367,6 +367,17 @@ exit:
 }
 
 func (w *Producer) popTransaction(frameType int32, data []byte) {
+	if len(w.transactions) == 0 {
+		dataLen := len(data)
+		if dataLen > 32 {
+			data = data[:32]
+		}
+		w.log(LogLevelError,
+			"(%s) unexpected response type=%d len=%d data[:32]=0x%x",
+			w.conn.String(), frameType, dataLen, data)
+		w.close()
+		return
+	}
 	t := w.transactions[0]
 	w.transactions = w.transactions[1:]
 	if frameType == FrameTypeError {


### PR DESCRIPTION
This corner case generally should not happen, but a nsqd bug or
strange network condition could possibly send erroneous bytes that
are interpreted as a response. The Producer should be robust,
and not panic the whole process.

fixes #345 (hopefully)