### PR TITLE
remove empty interface from SetBehaviorDelegate signature

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -266,19 +266,8 @@ func (r *Consumer) getLogLevel() LogLevel {
 // of the following interfaces that modify the behavior
 // of the `Consumer`:
 //
-//    DiscoveryFilter
-//
-func (r *Consumer) SetBehaviorDelegate(cb interface{}) {
-	matched := false
-
-	if _, ok := cb.(DiscoveryFilter); ok {
-		matched = true
-	}
-
-	if !matched {
-		panic("behavior delegate does not have any recognized methods")
-	}
-
+//	DiscoveryFilter
+func (r *Consumer) SetBehaviorDelegate(cb DiscoveryFilter) {
 	r.behaviorDelegate = cb
 }
 


### PR DESCRIPTION
I removed the empty interface to better understand which object should be passed to the function and leave the check on compile time