### PR TITLE
producer: Integrate context.Context with publishing

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -184,7 +184,6 @@ func (c *Conn) ConnectWithContext(ctx context.Context) (*IdentifyResponse, error
 	// the timeout used is smallest of dialer.Timeout (config.DialTimeout) or context timeout
 	conn, err := dialer.DialContext(ctx, "tcp", c.addr)
 	if err != nil {
-		fmt.Println("dialer.DialContext error: ", err) // TODO: remove
 		return nil, err
 	}
 	c.conn = conn.(*net.TCPConn)
@@ -303,13 +302,11 @@ func (c *Conn) WriteCommand(cmd *Command) error {
 }
 
 func (c *Conn) WriteCommandWithContext(ctx context.Context, cmd *Command) error {
-	// would we want all of our usage of WriteCommand to be replaced with WriteCommandWithContext?
 	c.mtx.Lock()
 
 	var err error
 	select {
 	case <-ctx.Done():
-		fmt.Println("WriteCommandWithContext ctx.Done(): ", ctx.Err()) // TODO: remove
 		c.mtx.Unlock()
 		return ctx.Err()
 	default:

--- a/conn.go
+++ b/conn.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/flate"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -119,8 +120,7 @@ func NewConn(addr string, config *Config, delegate ConnDelegate) *Conn {
 // The logger parameter is an interface that requires the following
 // method to be implemented (such as the the stdlib log.Logger):
 //
-//    Output(calldepth int, s string)
-//
+//	Output(calldepth int, s string)
 func (c *Conn) SetLogger(l logger, lvl LogLevel, format string) {
 	c.logGuard.Lock()
 	defer c.logGuard.Unlock()
@@ -171,13 +171,20 @@ func (c *Conn) getLogLevel() LogLevel {
 // Connect dials and bootstraps the nsqd connection
 // (including IDENTIFY) and returns the IdentifyResponse
 func (c *Conn) Connect() (*IdentifyResponse, error) {
+	ctx := context.Background()
+	return c.ConnectWithContext(ctx)
+}
+
+func (c *Conn) ConnectWithContext(ctx context.Context) (*IdentifyResponse, error) {
 	dialer := &net.Dialer{
 		LocalAddr: c.config.LocalAddr,
 		Timeout:   c.config.DialTimeout,
 	}
 
-	conn, err := dialer.Dial("tcp", c.addr)
+	// the timeout used is smallest of dialer.Timeout (config.DialTimeout) or context timeout
+	conn, err := dialer.DialContext(ctx, "tcp", c.addr)
 	if err != nil {
+		fmt.Println("dialer.DialContext error: ", err) // TODO: remove
 		return nil, err
 	}
 	c.conn = conn.(*net.TCPConn)
@@ -190,7 +197,7 @@ func (c *Conn) Connect() (*IdentifyResponse, error) {
 		return nil, fmt.Errorf("[%s] failed to write magic - %s", c.addr, err)
 	}
 
-	resp, err := c.identify()
+	resp, err := c.identify(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +207,7 @@ func (c *Conn) Connect() (*IdentifyResponse, error) {
 			c.log(LogLevelError, "Auth Required")
 			return nil, errors.New("Auth Required")
 		}
-		err := c.auth(c.config.AuthSecret)
+		err := c.auth(ctx, c.config.AuthSecret)
 		if err != nil {
 			c.log(LogLevelError, "Auth Failed %s", err)
 			return nil, err
@@ -291,13 +298,28 @@ func (c *Conn) Write(p []byte) (int, error) {
 // WriteCommand is a goroutine safe method to write a Command
 // to this connection, and flush.
 func (c *Conn) WriteCommand(cmd *Command) error {
+	ctx := context.Background()
+	return c.WriteCommandWithContext(ctx, cmd)
+}
+
+func (c *Conn) WriteCommandWithContext(ctx context.Context, cmd *Command) error {
+	// would we want all of our usage of WriteCommand to be replaced with WriteCommandWithContext?
 	c.mtx.Lock()
 
-	_, err := cmd.WriteTo(c)
-	if err != nil {
+	var err error
+	select {
+	case <-ctx.Done():
+		fmt.Println("WriteCommandWithContext ctx.Done(): ", ctx.Err()) // TODO: remove
+		c.mtx.Unlock()
+		return ctx.Err()
+	default:
+		_, err := cmd.WriteTo(c)
+		if err != nil {
+			goto exit
+		}
+		err = c.Flush()
 		goto exit
 	}
-	err = c.Flush()
 
 exit:
 	c.mtx.Unlock()
@@ -320,7 +342,7 @@ func (c *Conn) Flush() error {
 	return nil
 }
 
-func (c *Conn) identify() (*IdentifyResponse, error) {
+func (c *Conn) identify(ctx context.Context) (*IdentifyResponse, error) {
 	ci := make(map[string]interface{})
 	ci["client_id"] = c.config.ClientID
 	ci["hostname"] = c.config.Hostname
@@ -350,7 +372,7 @@ func (c *Conn) identify() (*IdentifyResponse, error) {
 		return nil, ErrIdentify{err.Error()}
 	}
 
-	err = c.WriteCommand(cmd)
+	err = c.WriteCommandWithContext(ctx, cmd)
 	if err != nil {
 		return nil, ErrIdentify{err.Error()}
 	}
@@ -479,13 +501,13 @@ func (c *Conn) upgradeSnappy() error {
 	return nil
 }
 
-func (c *Conn) auth(secret string) error {
+func (c *Conn) auth(ctx context.Context, secret string) error {
 	cmd, err := Auth(secret)
 	if err != nil {
 		return err
 	}
 
-	err = c.WriteCommand(cmd)
+	err = c.WriteCommandWithContext(ctx, cmd)
 	if err != nil {
 		return err
 	}

--- a/conn.go
+++ b/conn.go
@@ -310,7 +310,7 @@ func (c *Conn) WriteCommandWithContext(ctx context.Context, cmd *Command) error 
 		c.mtx.Unlock()
 		return ctx.Err()
 	default:
-		_, err := cmd.WriteTo(c)
+		_, err = cmd.WriteTo(c)
 		if err != nil {
 			goto exit
 		}

--- a/conn.go
+++ b/conn.go
@@ -175,6 +175,8 @@ func (c *Conn) Connect() (*IdentifyResponse, error) {
 	return c.ConnectWithContext(ctx)
 }
 
+// ConnectWithContext dials and bootstraps the nsqd connection
+// (including IDENTIFY) and returns the IdentifyResponse
 func (c *Conn) ConnectWithContext(ctx context.Context) (*IdentifyResponse, error) {
 	dialer := &net.Dialer{
 		LocalAddr: c.config.LocalAddr,
@@ -301,6 +303,8 @@ func (c *Conn) WriteCommand(cmd *Command) error {
 	return c.WriteCommandWithContext(ctx, cmd)
 }
 
+// WriteCommandWithContext is a goroutine safe method to write a Command
+// to this connection, and flush.
 func (c *Conn) WriteCommandWithContext(ctx context.Context, cmd *Command) error {
 	c.mtx.Lock()
 

--- a/producer.go
+++ b/producer.go
@@ -1,6 +1,7 @@
 package nsq
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -15,8 +16,10 @@ type producerConn interface {
 	SetLoggerLevel(LogLevel)
 	SetLoggerForLevel(logger, LogLevel, string)
 	Connect() (*IdentifyResponse, error)
+	ConnectWithContext(context.Context) (*IdentifyResponse, error)
 	Close() error
 	WriteCommand(*Command) error
+	WriteCommandWithContext(context.Context, *Command) error
 }
 
 // Producer is a high-level type to publish to NSQ.
@@ -53,6 +56,7 @@ type Producer struct {
 // to retrieve metadata about the command after the
 // response is received.
 type ProducerTransaction struct {
+	ctx      context.Context
 	cmd      *Command
 	doneChan chan *ProducerTransaction
 	Error    error         // the error (or nil) of the publish command
@@ -105,14 +109,19 @@ func NewProducer(addr string, config *Config) (*Producer, error) {
 // configured correctly, rather than relying on the lazy "connect on Publish"
 // behavior of a Producer.
 func (w *Producer) Ping() error {
+	ctx := context.Background()
+	return w.PingWithContext(ctx)
+}
+
+func (w *Producer) PingWithContext(ctx context.Context) error {
 	if atomic.LoadInt32(&w.state) != StateConnected {
-		err := w.connect()
+		err := w.connect(ctx)
 		if err != nil {
 			return err
 		}
 	}
 
-	return w.conn.WriteCommand(Nop())
+	return w.conn.WriteCommandWithContext(ctx, Nop())
 }
 
 // SetLogger assigns the logger to use as well as a level
@@ -120,8 +129,7 @@ func (w *Producer) Ping() error {
 // The logger parameter is an interface that requires the following
 // method to be implemented (such as the the stdlib log.Logger):
 //
-//    Output(calldepth int, s string)
-//
+//	Output(calldepth int, s string)
 func (w *Producer) SetLogger(l logger, lvl LogLevel) {
 	w.logGuard.Lock()
 	defer w.logGuard.Unlock()
@@ -192,7 +200,13 @@ func (w *Producer) Stop() {
 // and the response error if present
 func (w *Producer) PublishAsync(topic string, body []byte, doneChan chan *ProducerTransaction,
 	args ...interface{}) error {
-	return w.sendCommandAsync(Publish(topic, body), doneChan, args)
+	ctx := context.Background()
+	return w.PublishAsyncWithContext(ctx, topic, body, doneChan, args...)
+}
+
+func (w *Producer) PublishAsyncWithContext(ctx context.Context, topic string, body []byte, doneChan chan *ProducerTransaction,
+	args ...interface{}) error {
+	return w.sendCommandAsync(ctx, Publish(topic, body), doneChan, args)
 }
 
 // MultiPublishAsync publishes a slice of message bodies to the specified topic
@@ -204,34 +218,55 @@ func (w *Producer) PublishAsync(topic string, body []byte, doneChan chan *Produc
 // and the response error if present
 func (w *Producer) MultiPublishAsync(topic string, body [][]byte, doneChan chan *ProducerTransaction,
 	args ...interface{}) error {
+	ctx := context.Background()
+	return w.MultiPublishAsyncWithContext(ctx, topic, body, doneChan, args...)
+}
+
+func (w *Producer) MultiPublishAsyncWithContext(ctx context.Context, topic string, body [][]byte, doneChan chan *ProducerTransaction,
+	args ...interface{}) error {
 	cmd, err := MultiPublish(topic, body)
 	if err != nil {
 		return err
 	}
-	return w.sendCommandAsync(cmd, doneChan, args)
+	return w.sendCommandAsync(ctx, cmd, doneChan, args)
 }
 
 // Publish synchronously publishes a message body to the specified topic, returning
 // an error if publish failed
 func (w *Producer) Publish(topic string, body []byte) error {
-	return w.sendCommand(Publish(topic, body))
+	ctx := context.Background()
+	return w.PublishWithContext(ctx, topic, body)
+}
+
+func (w *Producer) PublishWithContext(ctx context.Context, topic string, body []byte) error {
+	return w.sendCommand(ctx, Publish(topic, body))
 }
 
 // MultiPublish synchronously publishes a slice of message bodies to the specified topic, returning
 // an error if publish failed
 func (w *Producer) MultiPublish(topic string, body [][]byte) error {
+	ctx := context.Background()
+	return w.MultiPublishWithContext(ctx, topic, body)
+}
+
+func (w *Producer) MultiPublishWithContext(ctx context.Context, topic string, body [][]byte) error {
 	cmd, err := MultiPublish(topic, body)
 	if err != nil {
 		return err
 	}
-	return w.sendCommand(cmd)
+	return w.sendCommand(ctx, cmd)
 }
 
 // DeferredPublish synchronously publishes a message body to the specified topic
 // where the message will queue at the channel level until the timeout expires, returning
 // an error if publish failed
 func (w *Producer) DeferredPublish(topic string, delay time.Duration, body []byte) error {
-	return w.sendCommand(DeferredPublish(topic, delay, body))
+	ctx := context.Background()
+	return w.DeferredPublishWithContext(ctx, topic, delay, body)
+}
+
+func (w *Producer) DeferredPublishWithContext(ctx context.Context, topic string, delay time.Duration, body []byte) error {
+	return w.sendCommand(ctx, DeferredPublish(topic, delay, body))
 }
 
 // DeferredPublishAsync publishes a message body to the specified topic
@@ -244,12 +279,18 @@ func (w *Producer) DeferredPublish(topic string, delay time.Duration, body []byt
 // and the response error if present
 func (w *Producer) DeferredPublishAsync(topic string, delay time.Duration, body []byte,
 	doneChan chan *ProducerTransaction, args ...interface{}) error {
-	return w.sendCommandAsync(DeferredPublish(topic, delay, body), doneChan, args)
+	ctx := context.Background()
+	return w.DeferredPublishAsyncWithContext(ctx, topic, delay, body, doneChan, args...)
 }
 
-func (w *Producer) sendCommand(cmd *Command) error {
+func (w *Producer) DeferredPublishAsyncWithContext(ctx context.Context, topic string, delay time.Duration, body []byte,
+	doneChan chan *ProducerTransaction, args ...interface{}) error {
+	return w.sendCommandAsync(ctx, DeferredPublish(topic, delay, body), doneChan, args)
+}
+
+func (w *Producer) sendCommand(ctx context.Context, cmd *Command) error {
 	doneChan := make(chan *ProducerTransaction)
-	err := w.sendCommandAsync(cmd, doneChan, nil)
+	err := w.sendCommandAsync(ctx, cmd, doneChan, nil)
 	if err != nil {
 		close(doneChan)
 		return err
@@ -258,7 +299,7 @@ func (w *Producer) sendCommand(cmd *Command) error {
 	return t.Error
 }
 
-func (w *Producer) sendCommandAsync(cmd *Command, doneChan chan *ProducerTransaction,
+func (w *Producer) sendCommandAsync(ctx context.Context, cmd *Command, doneChan chan *ProducerTransaction,
 	args []interface{}) error {
 	// keep track of how many outstanding producers we're dealing with
 	// in order to later ensure that we clean them all up...
@@ -266,13 +307,14 @@ func (w *Producer) sendCommandAsync(cmd *Command, doneChan chan *ProducerTransac
 	defer atomic.AddInt32(&w.concurrentProducers, -1)
 
 	if atomic.LoadInt32(&w.state) != StateConnected {
-		err := w.connect()
+		err := w.connect(ctx)
 		if err != nil {
 			return err
 		}
 	}
 
 	t := &ProducerTransaction{
+		ctx:      ctx,
 		cmd:      cmd,
 		doneChan: doneChan,
 		Args:     args,
@@ -282,12 +324,15 @@ func (w *Producer) sendCommandAsync(cmd *Command, doneChan chan *ProducerTransac
 	case w.transactionChan <- t:
 	case <-w.exitChan:
 		return ErrStopped
+	case <-ctx.Done():
+		fmt.Println("sendCommandAsync ctx.Done(): ", ctx.Err()) // TODO: remove
+		return ctx.Err()
 	}
 
 	return nil
 }
 
-func (w *Producer) connect() error {
+func (w *Producer) connect(ctx context.Context) error {
 	w.guard.Lock()
 	defer w.guard.Unlock()
 
@@ -312,7 +357,7 @@ func (w *Producer) connect() error {
 		w.conn.SetLoggerForLevel(w.logger[index], LogLevel(index), format)
 	}
 
-	_, err := w.conn.Connect()
+	_, err := w.conn.ConnectWithContext(ctx)
 	if err != nil {
 		w.conn.Close()
 		w.log(LogLevelError, "(%s) error connecting to nsqd - %s", w.addr, err)
@@ -344,9 +389,17 @@ func (w *Producer) router() {
 		select {
 		case t := <-w.transactionChan:
 			w.transactions = append(w.transactions, t)
-			err := w.conn.WriteCommand(t.cmd)
+			err := w.conn.WriteCommandWithContext(t.ctx, t.cmd)
 			if err != nil {
 				w.log(LogLevelError, "(%s) sending command - %s", w.conn.String(), err)
+				if err == context.Canceled || err == context.DeadlineExceeded {
+					// keep the connection alive if related to context timeout
+					// need to do some stuff that's in Producer.popTransaction here
+					w.transactions = w.transactions[1:]
+					t.Error = err
+					t.finish()
+					continue
+				}
 				w.close()
 			}
 		case data := <-w.responseChan:

--- a/producer.go
+++ b/producer.go
@@ -325,7 +325,6 @@ func (w *Producer) sendCommandAsync(ctx context.Context, cmd *Command, doneChan 
 	case <-w.exitChan:
 		return ErrStopped
 	case <-ctx.Done():
-		fmt.Println("sendCommandAsync ctx.Done(): ", ctx.Err()) // TODO: remove
 		return ctx.Err()
 	}
 

--- a/producer.go
+++ b/producer.go
@@ -2,6 +2,7 @@ package nsq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -426,22 +427,16 @@ func (w *Producer) router() {
 			err := w.conn.WriteCommandWithContext(t.ctx, t.cmd)
 			if err != nil {
 				w.log(LogLevelError, "(%s) sending command - %s", w.conn.String(), err)
-
-				switch err {
-				case context.Canceled:
-					w.popTransaction(FrameTypeContextCanceled, []byte(err.Error()))
-					continue
-				case context.DeadlineExceeded:
-					w.popTransaction(FrameTypeContextDeadlineExceeded, []byte(err.Error()))
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					w.popTransaction(-1, []byte{}, err)
 					continue
 				}
-
 				w.close()
 			}
 		case data := <-w.responseChan:
-			w.popTransaction(FrameTypeResponse, data)
+			w.popTransaction(FrameTypeResponse, data, nil)
 		case data := <-w.errorChan:
-			w.popTransaction(FrameTypeError, data)
+			w.popTransaction(FrameTypeError, data, nil)
 		case <-w.closeChan:
 			goto exit
 		case <-w.exitChan:
@@ -455,7 +450,7 @@ exit:
 	w.log(LogLevelInfo, "(%s) exiting router", w.conn.String())
 }
 
-func (w *Producer) popTransaction(frameType int32, data []byte) {
+func (w *Producer) popTransaction(frameType int32, data []byte, ctxErr error) {
 	if len(w.transactions) == 0 {
 		dataLen := len(data)
 		if dataLen > 32 {
@@ -470,13 +465,10 @@ func (w *Producer) popTransaction(frameType int32, data []byte) {
 	t := w.transactions[0]
 	w.transactions = w.transactions[1:]
 
-	switch frameType {
-	case FrameTypeError:
+	if frameType == FrameTypeError {
 		t.Error = ErrProtocol{string(data)}
-	case FrameTypeContextCanceled:
-		t.Error = context.Canceled
-	case FrameTypeContextDeadlineExceeded:
-		t.Error = context.DeadlineExceeded
+	} else if ctxErr != nil {
+		t.Error = ctxErr
 	}
 
 	t.finish()

--- a/producer.go
+++ b/producer.go
@@ -102,7 +102,7 @@ func NewProducer(addr string, config *Config) (*Producer, error) {
 	return p, nil
 }
 
-// Ping causes the Producer to connect to it's configured nsqd (if not already
+// Ping causes the Producer to connect to its configured nsqd (if not already
 // connected) and send a `Nop` command, returning any error that might occur.
 //
 // This method can be used to verify that a newly-created Producer instance is
@@ -113,6 +113,12 @@ func (w *Producer) Ping() error {
 	return w.PingWithContext(ctx)
 }
 
+// PingWithContext causes the Producer to connect to its configured nsqd (if not already
+// connected) and send a `Nop` command, returning any error that might occur.
+//
+// This method can be used to verify that a newly-created Producer instance is
+// configured correctly, rather than relying on the lazy "connect on Publish"
+// behavior of a Producer.
 func (w *Producer) PingWithContext(ctx context.Context) error {
 	if atomic.LoadInt32(&w.state) != StateConnected {
 		err := w.connect(ctx)
@@ -204,6 +210,13 @@ func (w *Producer) PublishAsync(topic string, body []byte, doneChan chan *Produc
 	return w.PublishAsyncWithContext(ctx, topic, body, doneChan, args...)
 }
 
+// PublishAsyncWithContext publishes a message body to the specified topic
+// but does not wait for the response from `nsqd`.
+//
+// When the Producer eventually receives the response from `nsqd`,
+// the supplied `doneChan` (if specified)
+// will receive a `ProducerTransaction` instance with the supplied variadic arguments
+// and the response error if present
 func (w *Producer) PublishAsyncWithContext(ctx context.Context, topic string, body []byte, doneChan chan *ProducerTransaction,
 	args ...interface{}) error {
 	return w.sendCommandAsync(ctx, Publish(topic, body), doneChan, args)
@@ -222,6 +235,13 @@ func (w *Producer) MultiPublishAsync(topic string, body [][]byte, doneChan chan 
 	return w.MultiPublishAsyncWithContext(ctx, topic, body, doneChan, args...)
 }
 
+// MultiPublishAsyncWithContext publishes a slice of message bodies to the specified topic
+// but does not wait for the response from `nsqd`.
+//
+// When the Producer eventually receives the response from `nsqd`,
+// the supplied `doneChan` (if specified)
+// will receive a `ProducerTransaction` instance with the supplied variadic arguments
+// and the response error if present
 func (w *Producer) MultiPublishAsyncWithContext(ctx context.Context, topic string, body [][]byte, doneChan chan *ProducerTransaction,
 	args ...interface{}) error {
 	cmd, err := MultiPublish(topic, body)
@@ -238,6 +258,8 @@ func (w *Producer) Publish(topic string, body []byte) error {
 	return w.PublishWithContext(ctx, topic, body)
 }
 
+// PublishWithContext synchronously publishes a message body to the specified topic, returning
+// an error if publish failed
 func (w *Producer) PublishWithContext(ctx context.Context, topic string, body []byte) error {
 	return w.sendCommand(ctx, Publish(topic, body))
 }
@@ -249,6 +271,8 @@ func (w *Producer) MultiPublish(topic string, body [][]byte) error {
 	return w.MultiPublishWithContext(ctx, topic, body)
 }
 
+// MultiPublishWithContext synchronously publishes a slice of message bodies to the specified topic, returning
+// an error if publish failed
 func (w *Producer) MultiPublishWithContext(ctx context.Context, topic string, body [][]byte) error {
 	cmd, err := MultiPublish(topic, body)
 	if err != nil {
@@ -265,6 +289,9 @@ func (w *Producer) DeferredPublish(topic string, delay time.Duration, body []byt
 	return w.DeferredPublishWithContext(ctx, topic, delay, body)
 }
 
+// DeferredPublishWithContext synchronously publishes a message body to the specified topic
+// where the message will queue at the channel level until the timeout expires, returning
+// an error if publish failed
 func (w *Producer) DeferredPublishWithContext(ctx context.Context, topic string, delay time.Duration, body []byte) error {
 	return w.sendCommand(ctx, DeferredPublish(topic, delay, body))
 }
@@ -283,6 +310,14 @@ func (w *Producer) DeferredPublishAsync(topic string, delay time.Duration, body 
 	return w.DeferredPublishAsyncWithContext(ctx, topic, delay, body, doneChan, args...)
 }
 
+// DeferredPublishAsyncWithContext publishes a message body to the specified topic
+// where the message will queue at the channel level until the timeout expires
+// but does not wait for the response from `nsqd`.
+//
+// When the Producer eventually receives the response from `nsqd`,
+// the supplied `doneChan` (if specified)
+// will receive a `ProducerTransaction` instance with the supplied variadic arguments
+// and the response error if present
 func (w *Producer) DeferredPublishAsyncWithContext(ctx context.Context, topic string, delay time.Duration, body []byte,
 	doneChan chan *ProducerTransaction, args ...interface{}) error {
 	return w.sendCommandAsync(ctx, DeferredPublish(topic, delay, body), doneChan, args)

--- a/producer_test.go
+++ b/producer_test.go
@@ -122,7 +122,7 @@ func TestProducerPublishWithContext(t *testing.T) {
 	// with the low timeout, the DialContext will fail and close conn, so Ping w/ out context first
 	w.Ping()
 
-	timeout := time.Duration(10) * time.Microsecond
+	timeout := time.Duration(5) * time.Microsecond
 	for i := 0; i < publishAttempts; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
@@ -132,7 +132,6 @@ func TestProducerPublishWithContext(t *testing.T) {
 			if err != context.DeadlineExceeded {
 				t.Fatalf("error %s", err)
 			}
-			t.Logf("error %s", err)
 			publishFailures++
 		}
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -16,9 +16,11 @@ var MagicV2 = []byte("  V2")
 
 // frame types
 const (
-	FrameTypeResponse int32 = 0
-	FrameTypeError    int32 = 1
-	FrameTypeMessage  int32 = 2
+	FrameTypeResponse                int32 = 0
+	FrameTypeError                   int32 = 1
+	FrameTypeMessage                 int32 = 2
+	FrameTypeContextCanceled         int32 = 3
+	FrameTypeContextDeadlineExceeded int32 = 4
 )
 
 // Used to detect if an unexpected HTTP response is read
@@ -46,11 +48,11 @@ func isValidName(name string) bool {
 // ReadResponse is a client-side utility function to read from the supplied Reader
 // according to the NSQ protocol spec:
 //
-//    [x][x][x][x][x][x][x][x]...
-//    |  (int32) || (binary)
-//    |  4-byte  || N-byte
-//    ------------------------...
-//        size       data
+//	[x][x][x][x][x][x][x][x]...
+//	|  (int32) || (binary)
+//	|  4-byte  || N-byte
+//	------------------------...
+//	    size       data
 func ReadResponse(r io.Reader, maxMsgSize int32) ([]byte, error) {
 	var msgSize int32
 
@@ -84,11 +86,11 @@ func ReadResponse(r io.Reader, maxMsgSize int32) ([]byte, error) {
 // UnpackResponse is a client-side utility function that unpacks serialized data
 // according to NSQ protocol spec:
 //
-//    [x][x][x][x][x][x][x][x]...
-//    |  (int32) || (binary)
-//    |  4-byte  || N-byte
-//    ------------------------...
-//      frame ID     data
+//	[x][x][x][x][x][x][x][x]...
+//	|  (int32) || (binary)
+//	|  4-byte  || N-byte
+//	------------------------...
+//	  frame ID     data
 //
 // Returns a triplicate of: frame type, data ([]byte), error
 func UnpackResponse(response []byte) (int32, []byte, error) {

--- a/protocol.go
+++ b/protocol.go
@@ -16,11 +16,9 @@ var MagicV2 = []byte("  V2")
 
 // frame types
 const (
-	FrameTypeResponse                int32 = 0
-	FrameTypeError                   int32 = 1
-	FrameTypeMessage                 int32 = 2
-	FrameTypeContextCanceled         int32 = 3
-	FrameTypeContextDeadlineExceeded int32 = 4
+	FrameTypeResponse int32 = 0
+	FrameTypeError    int32 = 1
+	FrameTypeMessage  int32 = 2
 )
 
 // Used to detect if an unexpected HTTP response is read


### PR DESCRIPTION
This PR sets out to resolve [#360](https://github.com/nsqio/go-nsq/issues/360) with the integration of [context.Context](https://pkg.go.dev/context#Context) in the `nsq.Producer`. In order to maintain backwards compatibility, new methods were added that have names with the suffix `WithContext`. These new methods mostly correspond to those that a client would use to publish messages and they adhere to context timeouts/deadlines. Once the deadline has been reached, an error will be returned to the client and the given `ProducerTransaction` will be dropped/not published, all while keeping the connection to `nsqd` alive.

An overview of the new methods added are below:

### nsq.Conn
* ConnectWithContext
* WriteCommandWithContext

### nsq.Producer
* PingWithContext
* PublishWithContext
* MultiPublishWithContext
* DeferredPublishWithContext
* PublishAsyncWithContext
* MultiPublishAsyncWithContext
* DeferredPublishAsyncWithContext

The idea here being that these `WithContext` methods would essentially replace the existing ones eventually, which would be a breaking/major version change for `go-nsq`.