### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,26 +6,26 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         imgtag:
-          - "golang:1.15-buster"
-          - "golang:1.16-buster"
-          - "golang:1.17-buster"
+          - "golang:1.23-bullseye"
+          - "golang:1.24-bullseye"
         goarch:
           - "amd64"
         nsq_ver:
           - "nsq-1.1.0.linux-amd64.go1.10.3"
           - "nsq-1.2.0.linux-amd64.go1.12.9"
           - "nsq-1.2.1.linux-amd64.go1.16.6"
+          - "nsq-1.3.0.linux-amd64.go1.21.5"
         include:
           # test 386 only against latest version of NSQ
-          - imgtag: "golang:1.17-buster"
+          - imgtag: "golang:1.24-bullseye"
             goarch: "386"
-            nsq_ver: "nsq-1.2.1.linux-amd64.go1.16.6"
+            nsq_ver: "nsq-1.3.0.linux-amd64.go1.21.5"
           
     container: "${{matrix.imgtag}}"
     env:


### PR DESCRIPTION
This updates the Go and Nsq versions go-nsq CI runs against.

CI will only run on the most recent two Go versions.

Resolves #375