### PR TITLE
snappy: upgrade v1.0.0 - upstream archived

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/nsqio/go-nsq
 
 go 1.17
 
-require github.com/golang/snappy v0.0.4
+require github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
+github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=


### PR DESCRIPTION
The Go implementation of snappy is now archived, but we should at least update to the most recent version which contains an amd64 bugfix. I'm not aware of any announcement or context on why that library is archived suddenly when it's been stable for many years.

see https://github.com/golang/go/issues/71811